### PR TITLE
Add generic type information to map, fold, and expand methods.

### DIFF
--- a/lib/src/internal/copy_on_write_list.dart
+++ b/lib/src/internal/copy_on_write_list.dart
@@ -36,7 +36,7 @@ class CopyOnWriteList<E> implements List<E> {
   bool every(bool test(E element)) => _list.every(test);
 
   @override
-  Iterable expand(Iterable f(E element)) => _list.expand(f);
+  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E e)) => _list.expand(f);
 
   @override
   E get first => _list.first;
@@ -46,7 +46,8 @@ class CopyOnWriteList<E> implements List<E> {
       _list.firstWhere(test, orElse: orElse);
 
   @override
-  fold(initialValue, combine(previousValue, E element)) =>
+  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
+          dynamic/*=T*/ combine(var/*=T*/ previousValue, E element)) =>
       _list.fold(initialValue, combine);
 
   @override
@@ -81,7 +82,7 @@ class CopyOnWriteList<E> implements List<E> {
       _list.lastWhere(test, orElse: orElse);
 
   @override
-  Iterable map(f(E element)) => _list.map(f);
+  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(E e)) => _list.map(f);
 
   @override
   E reduce(E combine(E value, E element)) => _list.reduce(combine);

--- a/lib/src/internal/copy_on_write_set.dart
+++ b/lib/src/internal/copy_on_write_set.dart
@@ -42,7 +42,7 @@ class CopyOnWriteSet<E> implements Set<E> {
   bool every(bool test(E element)) => _set.every(test);
 
   @override
-  Iterable expand(Iterable f(E element)) => _set.expand(f);
+  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E e)) => _set.expand(f);
 
   @override
   E get first => _set.first;
@@ -52,7 +52,8 @@ class CopyOnWriteSet<E> implements Set<E> {
       _set.firstWhere(test, orElse: orElse);
 
   @override
-  fold(initialValue, combine(previousValue, E element)) =>
+  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
+          dynamic/*=T*/ combine(var/*=T*/ previousValue, E element)) =>
       _set.fold(initialValue, combine);
 
   @override
@@ -78,7 +79,7 @@ class CopyOnWriteSet<E> implements Set<E> {
       _set.lastWhere(test, orElse: orElse);
 
   @override
-  Iterable map(f(E element)) => _set.map(f);
+  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(E e)) => _set.map(f);
 
   @override
   E reduce(E combine(E value, E element)) => _set.reduce(combine);

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -112,13 +112,13 @@ class BuiltList<E> implements Iterable<E> {
   Iterator<E> get iterator => _list.iterator;
 
   @override
-  Iterable map(f(E element)) => _list.map(f);
+  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(E e)) => _list.map(f);
 
   @override
   Iterable<E> where(bool test(E element)) => _list.where(test);
 
   @override
-  Iterable expand(Iterable f(E element)) => _list.expand(f);
+  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E e)) => _list.expand(f);
 
   @override
   bool contains(Object element) => _list.contains(element);
@@ -130,8 +130,8 @@ class BuiltList<E> implements Iterable<E> {
   E reduce(E combine(E value, E element)) => _list.reduce(combine);
 
   @override
-  dynamic fold(
-          var initialValue, dynamic combine(var previousValue, E element)) =>
+  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
+          dynamic/*=T*/ combine(var/*=T*/ previousValue, E element)) =>
       _list.fold(initialValue, combine);
 
   @override

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -106,13 +106,13 @@ class BuiltSet<E> implements Iterable<E> {
   Iterator<E> get iterator => _set.iterator;
 
   @override
-  Iterable map(f(E element)) => _set.map(f);
+  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(E e)) => _set.map(f);
 
   @override
   Iterable<E> where(bool test(E element)) => _set.where(test);
 
   @override
-  Iterable expand(Iterable f(E element)) => _set.expand(f);
+  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E e)) => _set.expand(f);
 
   @override
   bool contains(Object element) => _set.contains(element);
@@ -124,8 +124,8 @@ class BuiltSet<E> implements Iterable<E> {
   E reduce(E combine(E value, E element)) => _set.reduce(combine);
 
   @override
-  dynamic fold(
-          var initialValue, dynamic combine(var previousValue, E element)) =>
+  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
+          dynamic/*=T*/ combine(var/*=T*/ previousValue, E element)) =>
       _set.fold(initialValue, combine);
 
   @override


### PR DESCRIPTION
Without this, using the built collections in strong mode requires explicit casting.

To fix https://github.com/google/built_collection.dart/issues/53.

I've not added tests. I can look at adding some similar to https://github.com/dart-lang/sdk/blob/2ef00b0c3d0182b5e4ea5ca55fd00b9d038ae40d/pkg/analyzer/test/src/task/strong/inferred_type_test.dart but it would require a dependency on the analyzer package.