### PR TITLE
Clean up some strong mode warnings

### DIFF
--- a/lib/src/internal/copy_on_write_map.dart
+++ b/lib/src/internal/copy_on_write_map.dart
@@ -48,7 +48,7 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   }
 
   @override
-  void addAll(Map other) {
+  void addAll(Map<K, V> other) {
     _maybeCopyBeforeWrite();
     _map.addAll(other);
   }

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -166,11 +166,12 @@ class BuiltListMultimap<K, V> {
     _checkGenericTypeParameter();
 
     for (final key in keys) {
-      if (key is! K) {
+      if (key is K) {
+        _map[key] = new BuiltList<V>(lookup(key));
+      } else {
         throw new ArgumentError('map contained invalid key: ${key}');
       }
 
-      _map[key] = new BuiltList<V>(lookup(key));
     }
   }
 

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -89,14 +89,14 @@ class ListMultimapBuilder<K, V> {
       throw new ArgumentError('expected value or values to be set, got both');
     }
 
-    if (key == null) key = (x) => x;
+    if (key == null) key = (K x) => x;
 
     if (values != null) {
       for (final element in iterable) {
         this.addValues(key(element), values(element));
       }
     } else {
-      if (value == null) value = (x) => x;
+      if (value == null) value = (V x) => x;
       for (final element in iterable) {
         this.add(key(element), value(element));
       }
@@ -190,12 +190,12 @@ class ListMultimapBuilder<K, V> {
     _builderMap = new Map<K, ListBuilder<V>>();
 
     for (final key in keys) {
-      if (key is! K) {
+      if (key is K) {
+        for (final value in lookup(key)) {
+          add(key, value);
+        }
+      } else {
         throw new ArgumentError('map contained invalid key: ${key}');
-      }
-
-      for (final value in lookup(key)) {
-        add(key, value);
       }
     }
   }

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -143,16 +143,16 @@ class BuiltMap<K, V> {
     _checkGenericTypeParameter();
 
     for (final key in keys) {
-      if (key is! K) {
+      if (key is K) {
+        final value = lookup(key);
+        if (value is V) {
+          _map[key] = value;
+        } else {
+          throw new ArgumentError('map contained invalid value: ${value}');
+        }
+      } else {
         throw new ArgumentError('map contained invalid key: ${key}');
       }
-
-      final value = lookup(key);
-      if (value is! V) {
-        throw new ArgumentError('map contained invalid value: ${value}');
-      }
-
-      _map[key] = value;
     }
   }
 

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -198,11 +198,12 @@ class BuiltSet<E> implements Iterable<E> {
     _checkGenericTypeParameter();
 
     for (final element in iterable) {
-      if (element is! E) {
+      if (element is E) {
+        _set.add(element);
+      } else {
         throw new ArgumentError(
             'iterable contained invalid element: ${element}');
       }
-      _set.add(element);
     }
   }
 

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -52,7 +52,11 @@ class SetBuilder<E> {
       // Can't use addAll because it requires an Iterable<E>.
       final Set<E> set = new Set<E>();
       for (final element in iterable) {
-        set.add(element);
+        if (element is E) {
+          set.add(element);
+        } else {
+          throw new ArgumentError('iterable contained invalid element: ${key}');
+        }
       }
       _setSafeSet(set);
     }

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -166,11 +166,11 @@ class BuiltSetMultimap<K, V> {
     _checkGenericTypeParameter();
 
     for (final key in keys) {
-      if (key is! K) {
+      if (key is K) {
+        _map[key] = new BuiltSet<V>(lookup(key));
+      } else {
         throw new ArgumentError('map contained invalid key: ${key}');
       }
-
-      _map[key] = new BuiltSet<V>(lookup(key));
     }
   }
 

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -89,14 +89,14 @@ class SetMultimapBuilder<K, V> {
       throw new ArgumentError('expected value or values to be set, got both');
     }
 
-    if (key == null) key = (x) => x;
+    if (key == null) key = (K x) => x;
 
     if (values != null) {
       for (final element in iterable) {
         this.addValues(key(element), values(element));
       }
     } else {
-      if (value == null) value = (x) => x;
+      if (value == null) value = (V x) => x;
       for (final element in iterable) {
         this.add(key(element), value(element));
       }
@@ -190,13 +190,14 @@ class SetMultimapBuilder<K, V> {
     _builderMap = new Map<K, SetBuilder<V>>();
 
     for (final key in keys) {
-      if (key is! K) {
+      if (key is K) {
+        for (final value in lookup(key)) {
+          add(key, value);
+        }
+      } else {
         throw new ArgumentError('map contained invalid key: ${key}');
       }
 
-      for (final value in lookup(key)) {
-        add(key, value);
-      }
     }
   }
 


### PR DESCRIPTION
This PR fixes some strong mode warnings. Let me know if you're not into it. It fixes things where analyzer doesn't understand:

```dart
if (foo is! K) {
  throw;
}
K bar = foo; // foo is obviously a K
```

I don't see an open bug on analyzer for this...