### PR TITLE
Make built collections strong mode compliant

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -16,10 +16,10 @@ part 'list/list_builder.dart';
 
 // Internal only, for testing.
 class OverriddenHashcodeBuiltList<T> extends BuiltList<T> {
-  final int _hashCode;
+  final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltList(Iterable iterable, this._hashCode)
+  OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
       : super._copyAndCheck(iterable);
 
-  int get hashCode => _hashCode;
+  int get hashCode => _overridenHashCode;
 }

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -27,7 +27,7 @@ class BuiltList<E> implements Iterable<E> {
   /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltList([Iterable iterable = const []]) {
     if (iterable is BuiltList && iterable._hasExactElementType(E)) {
-      return iterable;
+      return iterable as BuiltList<E>;
     } else {
       return new BuiltList<E>._copyAndCheck(iterable);
     }

--- a/lib/src/list_multimap.dart
+++ b/lib/src/list_multimap.dart
@@ -17,10 +17,10 @@ part 'list_multimap/list_multimap_builder.dart';
 // Internal only, for testing.
 class OverriddenHashcodeBuiltListMultimap<K, V>
     extends BuiltListMultimap<K, V> {
-  final int _hashCode;
+  final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltListMultimap(map, this._hashCode)
+  OverriddenHashcodeBuiltListMultimap(map, this._overridenHashCode)
       : super._copyAndCheck(map.keys, (k) => map[k]);
 
-  int get hashCode => _hashCode;
+  int get hashCode => _overridenHashCode;
 }

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -37,7 +37,7 @@ class BuiltListMultimap<K, V> {
   factory BuiltListMultimap([multimap = const {}]) {
     if (multimap is BuiltListMultimap &&
         multimap._hasExactKeyAndValueTypes(K, V)) {
-      return multimap;
+      return multimap as BuiltListMultimap<K, V>;
     } else if (multimap is Map ||
         multimap is ListMultimap ||
         multimap is BuiltListMultimap) {

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -130,17 +130,21 @@ class ListMultimapBuilder<K, V> {
   }
 
   /// As [ListMultimap.remove] but returns nothing.
-  void remove(K key, V value) {
-    _makeWriteableCopy();
-    _getValuesBuilder(key).remove(value);
+  void remove(Object key, V value) {
+    if (key is K) {
+      _makeWriteableCopy();
+      _getValuesBuilder(key).remove(value);
+    }
   }
 
   /// As [ListMultimap.removeAll] but returns nothing.
-  void removeAll(K key) {
-    _makeWriteableCopy();
+  void removeAll(Object key) {
+    if (key is K) {
+      _makeWriteableCopy();
 
-    _builtMap = _builtMap;
-    _builderMap[key] = new ListBuilder<V>();
+      _builtMap = _builtMap;
+      _builderMap[key] = new ListBuilder<V>();
+    }
   }
 
   /// As [ListMultimap.clear].
@@ -192,7 +196,11 @@ class ListMultimapBuilder<K, V> {
     for (final key in keys) {
       if (key is K) {
         for (final value in lookup(key)) {
-          add(key, value as V);
+          if (value is V) {
+            add(key, value);
+          } else {
+            throw new ArgumentError('map contained invalid value: ${value}, for key ${key}');
+          }
         }
       } else {
         throw new ArgumentError('map contained invalid key: ${key}');

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -130,13 +130,13 @@ class ListMultimapBuilder<K, V> {
   }
 
   /// As [ListMultimap.remove] but returns nothing.
-  void remove(Object key, V value) {
+  void remove(K key, V value) {
     _makeWriteableCopy();
     _getValuesBuilder(key).remove(value);
   }
 
   /// As [ListMultimap.removeAll] but returns nothing.
-  void removeAll(Object key) {
+  void removeAll(K key) {
     _makeWriteableCopy();
 
     _builtMap = _builtMap;
@@ -192,7 +192,7 @@ class ListMultimapBuilder<K, V> {
     for (final key in keys) {
       if (key is K) {
         for (final value in lookup(key)) {
-          add(key, value);
+          add(key, value as V);
         }
       } else {
         throw new ArgumentError('map contained invalid key: ${key}');

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -13,10 +13,10 @@ part 'map/map_builder.dart';
 
 // Internal only, for testing.
 class OverriddenHashcodeBuiltMap<K, V> extends BuiltMap<K, V> {
-  final int _hashCode;
+  final int _overrridenHashCode;
 
-  OverriddenHashcodeBuiltMap(map, this._hashCode)
+  OverriddenHashcodeBuiltMap(map, this._overrridenHashCode)
       : super._copyAndCheck(map.keys, (k) => map[k]);
 
-  int get hashCode => _hashCode;
+  int get hashCode => _overrridenHashCode;
 }

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -32,7 +32,7 @@ class BuiltMap<K, V> {
   /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap([map = const {}]) {
     if (map is BuiltMap && map._hasExactKeyAndValueTypes(K, V)) {
-      return map;
+      return map as BuiltMap<K, V>;
     } else if (map is Map || map is BuiltMap) {
       return new BuiltMap<K, V>._copyAndCheck(map.keys, (k) => map[k]);
     } else {

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -62,8 +62,8 @@ class MapBuilder<K, V> {
   ///
   /// [key] and [value] default to the identity function.
   void addIterable(Iterable iterable, {K key(element), V value(element)}) {
-    if (key == null) key = (x) => x;
-    if (value == null) value = (x) => x;
+    if (key == null) key = (x) => x as K;
+    if (value == null) value = (x) => x as V;
     for (final element in iterable) {
       this[key(element)] = value(element);
     }

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -14,10 +14,10 @@ part 'set/set_builder.dart';
 
 // Internal only, for testing.
 class OverriddenHashcodeBuiltSet<T> extends BuiltSet<T> {
-  final int _hashCode;
+  final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltSet(Iterable iterable, this._hashCode)
+  OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
       : super._copyAndCheck(iterable);
 
-  int get hashCode => _hashCode;
+  int get hashCode => _overridenHashCode;
 }

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -28,7 +28,7 @@ class BuiltSet<E> implements Iterable<E> {
   /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltSet([Iterable iterable = const []]) {
     if (iterable is BuiltSet && iterable._hasExactElementType(E)) {
-      return iterable;
+      return iterable as BuiltSet<E>;
     } else {
       return new BuiltSet<E>._copyAndCheck(iterable);
     }

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -55,7 +55,8 @@ class SetBuilder<E> {
         if (element is E) {
           set.add(element);
         } else {
-          throw new ArgumentError('iterable contained invalid element: ${key}');
+          throw new ArgumentError(
+              'iterable contained invalid element: ${element}');
         }
       }
       _setSafeSet(set);

--- a/lib/src/set_multimap.dart
+++ b/lib/src/set_multimap.dart
@@ -16,10 +16,10 @@ part 'set_multimap/set_multimap_builder.dart';
 
 // Internal only, for testing.
 class OverriddenHashcodeBuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
-  final int _hashCode;
+  final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltSetMultimap(map, this._hashCode)
+  OverriddenHashcodeBuiltSetMultimap(map, this._overridenHashCode)
       : super._copyAndCheck(map.keys, (k) => map[k]);
 
-  int get hashCode => _hashCode;
+  int get hashCode => _overridenHashCode;
 }

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -37,7 +37,7 @@ class BuiltSetMultimap<K, V> {
   factory BuiltSetMultimap([multimap = const {}]) {
     if (multimap is BuiltSetMultimap &&
         multimap._hasExactKeyAndValueTypes(K, V)) {
-      return multimap;
+      return multimap as BuiltSetMultimap<K, V>;
     } else if (multimap is Map ||
         multimap is SetMultimap ||
         multimap is BuiltSetMultimap) {

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -131,16 +131,20 @@ class SetMultimapBuilder<K, V> {
 
   /// As [SetMultimap.remove] but returns nothing.
   void remove(Object key, V value) {
-    _makeWriteableCopy();
-    _getValuesBuilder(key as K).remove(value);
+    if (key is K) {
+      _makeWriteableCopy();
+      _getValuesBuilder(key).remove(value);
+    }
   }
 
   /// As [SetMultimap.removeAll] but returns nothing.
-  void removeAll(K key) {
-    _makeWriteableCopy();
+  void removeAll(Object key) {
+    if (key is K) {
+      _makeWriteableCopy();
 
-    _builtMap = _builtMap;
-    _builderMap[key] = new SetBuilder<V>();
+      _builtMap = _builtMap;
+      _builderMap[key] = new SetBuilder<V>();
+    }
   }
 
   /// As [SetMultimap.clear].

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -130,9 +130,9 @@ class SetMultimapBuilder<K, V> {
   }
 
   /// As [SetMultimap.remove] but returns nothing.
-  void remove(K key, V value) {
+  void remove(Object key, V value) {
     _makeWriteableCopy();
-    _getValuesBuilder(key).remove(value);
+    _getValuesBuilder(key as K).remove(value);
   }
 
   /// As [SetMultimap.removeAll] but returns nothing.
@@ -192,7 +192,11 @@ class SetMultimapBuilder<K, V> {
     for (final key in keys) {
       if (key is K) {
         for (final value in lookup(key)) {
-          add(key, value as V);
+          if (value is V) {
+            add(key, value);
+          } else {
+            throw new ArgumentError('map contained invalid value: ${value}, for key ${key}');
+          }
         }
       } else {
         throw new ArgumentError('map contained invalid key: ${key}');

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -130,13 +130,13 @@ class SetMultimapBuilder<K, V> {
   }
 
   /// As [SetMultimap.remove] but returns nothing.
-  void remove(Object key, V value) {
+  void remove(K key, V value) {
     _makeWriteableCopy();
     _getValuesBuilder(key).remove(value);
   }
 
   /// As [SetMultimap.removeAll] but returns nothing.
-  void removeAll(Object key) {
+  void removeAll(K key) {
     _makeWriteableCopy();
 
     _builtMap = _builtMap;
@@ -192,7 +192,7 @@ class SetMultimapBuilder<K, V> {
     for (final key in keys) {
       if (key is K) {
         for (final value in lookup(key)) {
-          add(key, value);
+          add(key, value as V);
         }
       } else {
         throw new ArgumentError('map contained invalid key: ${key}');


### PR DESCRIPTION
This patch fixes all the strong mode issues with this lib, either field overrides or missing types in the constructors that do nothing or in the remove methods.

Errors such as these were fixed by using a different field name in list.dart, set.dart, etc. for the hashcode override.
lib/src/list.dart:19: [ERROR] Field declaration BuiltList<T>._hashCode cannot be overridden in OverriddenHashcodeBuiltList. [STRONG_MODE_INVALID_FIELD_OVERRIDE]

lib/src/list_multimap.dart:20: [ERROR] Field declaration BuiltListMultimap<K, V>._hashCode cannot be overridden in OverriddenHashcodeBuiltListMultimap. [STRONG_MODE_INVALID_FIELD_OVERRIDE]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/71)
<!-- Reviewable:end -->
