### PR TITLE
Add asCollection() methods to BuiltCollection classes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 #   Name/Organization <email address>
 
 David Morgan/Google Inc. <davidmorgan@google.com>
+Matan Lurey/Google Inc. <matanl@google.com>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.0
+
+- Add `asList`, `asMap`, and `asSet` to the built collection classes.
+
 ## 1.1.0
 
 - Remove runtime checks that are unnecessary if the project using

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ a copy, but return a copy-on-write wrapper. So, Built Collections can be
 efficiently and easily used with code that needs core SDK collections but
 does not mutate them.
 
+When you want to provide a collection that explicitly _throws_ when a
+mutation is attempted, use `BuiltList.asList`,
+`BuiltListMultimap.asMap`, `BuiltSet.asSet`, `BuiltSetMultimap.asMap` 
+and `BuiltMap.asMap`.
+
 ## Features and bugs
 
 Please file feature requests and bugs at the [issue tracker][tracker].

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -14,7 +14,7 @@ part of built_collection.list;
 /// for the general properties of Built Collections.
 class BuiltList<E> implements Iterable<E> {
   final List<E> _list;
-  int _hashCode = null;
+  int _hashCode;
 
   /// Instantiates with elements from an [Iterable].
   ///
@@ -79,6 +79,12 @@ class BuiltList<E> implements Iterable<E> {
 
   @override
   String toString() => _list.toString();
+
+  /// Returns as an immutable list.
+  ///
+  /// Useful when producing or using APIs that need the [List] interface. This
+  /// differs from [toList] where mutations are explicitly disallowed.
+  List<E> asList() => new List<E>.unmodifiable(_list);
 
   // List.
 

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -20,7 +20,7 @@ class BuiltListMultimap<K, V> {
   final BuiltList<V> _emptyList = new BuiltList<V>();
 
   // Cached.
-  int _hashCode = null;
+  int _hashCode;
   Iterable<K> _keys;
   Iterable<V> _values;
 
@@ -104,6 +104,12 @@ class BuiltListMultimap<K, V> {
   }
 
   String toString() => _map.toString();
+
+  /// Returns as an immutable map.
+  ///
+  /// Useful when producing or using APIs that need the [Map] interface. This
+  /// differs from [toMap] where mutations are explicitly disallowed.
+  Map<K, Iterable<V>> asMap() => new Map<K, Iterable<V>>.unmodifiable(_map);
 
   // ListMultimap.
 

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -54,6 +54,12 @@ class BuiltMap<K, V> {
   BuiltMap<K, V> rebuild(updates(MapBuilder<K, V> builder)) =>
       (toBuilder()..update(updates)).build();
 
+  /// Returns as an immutable map.
+  ///
+  /// Useful when producing or using APIs that need the [Map] interface. This
+  /// differs from [toMap] where mutations are explicitly disallowed.
+  Map<K, V> asMap() => new Map<K, V>.unmodifiable(_map);
+
   /// Converts to a [Map].
   ///
   /// Note that the implementation is efficient: it returns a copy-on-write

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -5,6 +5,7 @@
 library built_collection.set;
 
 import 'package:built_collection/src/list.dart' show BuiltList;
+import 'package:collection/collection.dart' show UnmodifiableSetView;
 import 'package:quiver/core.dart' show hashObjects;
 
 import 'internal/copy_on_write_set.dart';

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -79,6 +79,12 @@ class BuiltSet<E> implements Iterable<E> {
   @override
   String toString() => _set.toString();
 
+  /// Returns as an immutable set.
+  ///
+  /// Useful when producing or using APIs that need the [Set] interface. This
+  /// differs from [toSet] where mutations are explicitly disallowed.
+  Set<E> asSet() => new UnmodifiableSetView<E>(_set);
+
   // Set.
 
   /// As [Set.length].

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -20,7 +20,7 @@ class BuiltSetMultimap<K, V> {
   final BuiltSet<V> _emptySet = new BuiltSet<V>();
 
   // Cached.
-  int _hashCode = null;
+  int _hashCode;
   Iterable<K> _keys;
   Iterable<V> _values;
 
@@ -102,6 +102,12 @@ class BuiltSetMultimap<K, V> {
     }
     return true;
   }
+
+  /// Returns as an immutable map.
+  ///
+  /// Useful when producing or using APIs that need the [Map] interface. This
+  /// differs from [toMap] where mutations are explicitly disallowed.
+  Map<K, Iterable<V>> asMap() => new Map<K, Iterable<V>>.unmodifiable(_map);
 
   String toString() => _map.toString();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ authors:
 - Matan Lurey <matanl@google.com>
 homepage: https://github.com/google/built-collection-dart
 dependencies:
+  collection: '^1.7.0'
   quiver: '>=0.21.0 <0.24.0'
 dev_dependencies:
   test: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,6 +4,7 @@ description: >
   Builder pattern wrappers for core Dart collections.
 authors:
 - David Morgan <davidmorgan@google.com>
+- Matan Lurey <matanl@google.com>
 homepage: https://github.com/google/built-collection-dart
 dependencies:
   quiver: '>=0.21.0 <0.24.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_collection
-version: 1.1.0
+version: 1.2.0
 description: >
   Builder pattern wrappers for core Dart collections.
 authors:

--- a/test/list/built_list_test.dart
+++ b/test/list/built_list_test.dart
@@ -62,6 +62,13 @@ void main() {
       expect(new BuiltList<int>().toList() is List<String>, isFalse);
     });
 
+    test('can be converted to an UnmodifiableListView', () {
+      final immutableList = new BuiltList<int>().asList();
+      expect(immutableList is List<int>, isTrue);
+      expect(() => immutableList.add(1), throwsUnsupportedError);
+      expect(immutableList, isEmpty);
+    });
+
     test('can be converted to ListBuilder<E>', () {
       expect(new BuiltList<int>().toBuilder() is ListBuilder<int>, isTrue);
       expect(new BuiltList<int>().toBuilder() is ListBuilder<String>, isFalse);

--- a/test/list_multimap/built_list_multimap_test.dart
+++ b/test/list_multimap/built_list_multimap_test.dart
@@ -105,6 +105,13 @@ void main() {
           isFalse);
     });
 
+    test('can be converted to an UnmodifiableMapView', () {
+      final immutableMap = new BuiltListMultimap<int, String>().asMap();
+      expect(immutableMap is Map<int, Iterable<String>>, isTrue);
+      expect(() => immutableMap[1] = ['Hello'], throwsUnsupportedError);
+      expect(immutableMap, isEmpty);
+    });
+
     test('can be converted to ListMultimapBuilder<K, V>', () {
       expect(
           new BuiltListMultimap<int, String>().toBuilder()

--- a/test/map/built_map_test.dart
+++ b/test/map/built_map_test.dart
@@ -76,6 +76,13 @@ void main() {
           new BuiltMap<int, String>().toMap() is Map<String, String>, isFalse);
     });
 
+    test('can be converted to an UnmodifiableMapView', () {
+      final immutableMap = new BuiltMap<int, String>().asMap();
+      expect(immutableMap is Map<int, String>, isTrue);
+      expect(() => immutableMap[1] = 'Hello', throwsUnsupportedError);
+      expect(immutableMap, isEmpty);
+    });
+
     test('can be converted to MapBuilder<K, V>', () {
       expect(new BuiltMap<int, String>().toBuilder() is MapBuilder<int, String>,
           isTrue);

--- a/test/set/built_set_test.dart
+++ b/test/set/built_set_test.dart
@@ -62,6 +62,13 @@ void main() {
       expect(new BuiltSet<int>().toSet() is Set<String>, isFalse);
     });
 
+    test('can be converted to an UnmodifiableSetView', () {
+      final immutableSet = new BuiltSet<int>().asSet();
+      expect(immutableSet is Set<int>, isTrue);
+      expect(() => immutableSet.add(1), throwsUnsupportedError);
+      expect(immutableSet, isEmpty);
+    });
+
     test('can be converted to SetBuilder<E>', () {
       expect(new BuiltSet<int>().toBuilder() is SetBuilder<int>, isTrue);
       expect(new BuiltSet<int>().toBuilder() is SetBuilder<String>, isFalse);

--- a/test/set_multimap/built_set_multimap_test.dart
+++ b/test/set_multimap/built_set_multimap_test.dart
@@ -105,6 +105,13 @@ void main() {
           isFalse);
     });
 
+    test('can be converted to an UnmodifiableMapView', () {
+      final immutableMap = new BuiltSetMultimap<int, String>().asMap();
+      expect(immutableMap is Map<int, Iterable<String>>, isTrue);
+      expect(() => immutableMap[1] = ['Hello'], throwsUnsupportedError);
+      expect(immutableMap, isEmpty);
+    });
+
     test('can be converted to SetMultimapBuilder<K, V>', () {
       expect(
           new BuiltSetMultimap<int, String>().toBuilder()


### PR DESCRIPTION
Closes https://github.com/google/built_collection.dart/issues/77

## 1.2.0

- Add `asList`, `asMap`, and `asSet` to the built collection classes.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/79)
<!-- Reviewable:end -->
