### PR TITLE
Add BuiltIterable interface.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.5.0
+
+- Add BuiltIterable interface for when you want to accept a BuiltList or BuiltSet.
+
 ## 1.4.1
 
 - Use real generic syntax, drop comment-based syntax.

--- a/lib/src/iterable.dart
+++ b/lib/src/iterable.dart
@@ -1,0 +1,10 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+library built_collection.iterable;
+
+import 'package:built_collection/src/list.dart' show BuiltList;
+import 'package:built_collection/src/set.dart' show BuiltSet;
+
+part 'iterable/built_iterable.dart';

--- a/lib/src/iterable/built_iterable.dart
+++ b/lib/src/iterable/built_iterable.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2017, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+part of built_collection.iterable;
+
+/// [Iterable] that is either a [BuiltList] or a [BuiltSet].
+abstract class BuiltIterable<E> implements Iterable<E> {
+  /// Converts to a [BuiltList].
+  BuiltList<E> toBuiltList();
+
+  /// Converts to a [BuiltSet].
+  BuiltSet<E> toBuiltSet();
+}

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -6,6 +6,7 @@ library built_collection.list;
 
 import 'dart:math' show Random;
 
+import 'package:built_collection/src/iterable.dart' show BuiltIterable;
 import 'package:built_collection/src/set.dart' show BuiltSet;
 import 'package:quiver/core.dart' show hashObjects;
 

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -13,7 +13,7 @@ part of built_collection.list;
 /// [Built Collection library documentation]
 /// (#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltList<E> implements Iterable<E> {
+class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   final List<E> _list;
   int _hashCode;
 
@@ -47,7 +47,10 @@ class BuiltList<E> implements Iterable<E> {
   BuiltList<E> rebuild(updates(ListBuilder<E> builder)) =>
       (toBuilder()..update(updates)).build();
 
-  /// Converts to a [BuiltSet].
+  @override
+  BuiltList<E> toBuiltList() => this;
+
+  @override
   BuiltSet<E> toBuiltSet() => new BuiltSet<E>(this);
 
   /// Deep hashCode.

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -4,6 +4,7 @@
 
 library built_collection.set;
 
+import 'package:built_collection/src/iterable.dart' show BuiltIterable;
 import 'package:built_collection/src/list.dart' show BuiltList;
 import 'package:collection/collection.dart' show UnmodifiableSetView;
 import 'package:quiver/core.dart' show hashObjects;

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -13,7 +13,7 @@ part of built_collection.set;
 /// See the
 /// [Built Collection library documentation](#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltSet<E> implements Iterable<E> {
+class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   final Set<E> _set;
   int _hashCode;
 
@@ -47,8 +47,11 @@ class BuiltSet<E> implements Iterable<E> {
   BuiltSet<E> rebuild(updates(SetBuilder<E> builder)) =>
       (toBuilder()..update(updates)).build();
 
-  /// Converts to a [BuiltList].
+  @override
   BuiltList<E> toBuiltList() => new BuiltList<E>(this);
+
+  @override
+  BuiltSet<E> toBuiltSet() => this;
 
   /// Deep hashCode.
   ///

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: built_collection
-version: 1.4.1
+version: 1.5.0
 description: >
   Builder pattern wrappers for core Dart collections.
 authors:

--- a/test/list/built_list_test.dart
+++ b/test/list/built_list_test.dart
@@ -147,6 +147,11 @@ void main() {
       expect(new BuiltList<int>([1, 2, 3]).toString(), '[1, 2, 3]');
     });
 
+    test('returns identical with toBuiltList', () {
+      final list = new BuiltList<int>([0, 1, 2]);
+      expect(list.toBuiltList(), same(list));
+    });
+
     test('converts to BuiltSet with toBuiltSet', () {
       expect(new BuiltList<int>([0, 1, 2]).toBuiltSet(), [0, 1, 2]);
     });

--- a/test/set/built_set_test.dart
+++ b/test/set/built_set_test.dart
@@ -171,6 +171,11 @@ void main() {
       expect(new BuiltSet<int>([0, 1, 2]).toBuiltList(), [0, 1, 2]);
     });
 
+    test('returns identical with toBuiltSet', () {
+      final set = new BuiltSet<int>([0, 1, 2]);
+      expect(set.toBuiltSet(), same(set));
+    });
+
     // Lazy copies.
 
     test('reuses BuiltSet instances of the same type', () {


### PR DESCRIPTION
Relevant to #82 but does not fix it -- we don't yet use BuiltIterable as a return type. This just allows you to specify that you want a BuiltList or BuiltSet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/100)
<!-- Reviewable:end -->
