### PR TITLE
Make addIterable generic

### DIFF
--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -86,22 +86,22 @@ class ListMultimapBuilder<K, V> {
   ///
   /// [key] and [value] default to the identity function. [values] is ignored
   /// if not specified.
-  void addIterable(Iterable iterable,
-      {K key(dynamic element),
-      V value(dynamic element),
-      Iterable<V> values(dynamic element)}) {
+  void addIterable<T>(Iterable<T> iterable,
+      {K key(T element),
+      V value(T element),
+      Iterable<V> values(T element)}) {
     if (value != null && values != null) {
       throw new ArgumentError('expected value or values to be set, got both');
     }
 
-    if (key == null) key = (K x) => x;
+    if (key == null) key = (T x) => x as K;
 
     if (values != null) {
       for (final element in iterable) {
         this.addValues(key(element), values(element));
       }
     } else {
-      if (value == null) value = (V x) => x;
+      if (value == null) value = (T x) => x as V;
       for (final element in iterable) {
         this.add(key(element), value(element));
       }

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -61,10 +61,10 @@ class MapBuilder<K, V> {
   /// As [Map.fromIterable] but adds.
   ///
   /// [key] and [value] default to the identity function.
-  void addIterable(Iterable iterable,
-      {K key(dynamic element), V value(dynamic element)}) {
-    if (key == null) key = (x) => x as K;
-    if (value == null) value = (x) => x as V;
+  void addIterable<T>(Iterable<T> iterable,
+      {K key(T element), V value(T element)}) {
+    if (key == null) key = (T x) => x as K;
+    if (value == null) value = (T x) => x as V;
     for (final element in iterable) {
       this[key(element)] = value(element);
     }

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -85,22 +85,22 @@ class SetMultimapBuilder<K, V> {
   ///
   /// [key] and [value] default to the identity function. [values] is ignored
   /// if not specified.
-  void addIterable(Iterable iterable,
-      {K key(dynamic element),
-      V value(dynamic element),
-      Iterable<V> values(dynamic element)}) {
+  void addIterable<T>(Iterable<T> iterable,
+      {K key(T element),
+      V value(T element),
+      Iterable<V> values(T element)}) {
     if (value != null && values != null) {
       throw new ArgumentError('expected value or values to be set, got both');
     }
 
-    if (key == null) key = (K x) => x;
+    if (key == null) key = (T x) => x as K;
 
     if (values != null) {
       for (final element in iterable) {
         this.addValues(key(element), values(element));
       }
     } else {
-      if (value == null) value = (V x) => x;
+      if (value == null) value = (T x) => x as V;
       for (final element in iterable) {
         this.add(key(element), value(element));
       }


### PR DESCRIPTION
Related to https://github.com/dart-lang/sdk/issues/26392

This fixes  a warning with the last dart analyzer when I write: 
```dart
List<Node> nodes = [];
new MapBuilder<int, Node>().addIterable(nodes, key: (Node n) => n.id);
// info: A function of type '(Node) → int' can't be assigned to a variable of type '(dynamic) → int'. (uses_dynamic_as_bottom at ...)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/101)
<!-- Reviewable:end -->
