### PR TITLE
Separate BuiltList into interface and implementation class

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 
 David Morgan/Google Inc. <davidmorgan@google.com>
 Matan Lurey/Google Inc. <matanl@google.com>
+Philipp Schiffmann <philippschiffmann93@gmail.com>

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -16,11 +16,11 @@ part 'list/built_list.dart';
 part 'list/list_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltList<T> extends BuiltList<T> {
+class OverriddenHashcodeBuiltList<T> extends _BuiltList<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
-      : super._copyAndCheck(iterable);
+      : super.copyAndCheck(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -72,7 +72,7 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
-    if (other is! _BuiltList) return false;
+    if (other is! BuiltList) return false;
     if (other.length != length) return false;
     if (other.hashCode != hashCode) return false;
     for (var i = 0; i != length; ++i) {

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -27,10 +27,10 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   ///
   /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltList([Iterable iterable = const []]) {
-    if (iterable is BuiltList && iterable._hasExactElementType(E)) {
+    if (iterable is _BuiltList && iterable.hasExactElementType(E)) {
       return iterable as BuiltList<E>;
     } else {
-      return new BuiltList<E>._copyAndCheck(iterable);
+      return new _BuiltList<E>.copyAndCheck(iterable);
     }
   }
 
@@ -72,7 +72,7 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   @override
   bool operator ==(dynamic other) {
     if (identical(other, this)) return true;
-    if (other is! BuiltList) return false;
+    if (other is! _BuiltList) return false;
     if (other.length != length) return false;
     if (other.hashCode != hashCode) return false;
     for (var i = 0; i != length; ++i) {
@@ -110,7 +110,7 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
   /// As [List.sublist] but returns a `BuiltList<E>`.
   BuiltList<E> sublist(int start, [int end]) =>
-      new BuiltList<E>._withSafeList(_list.sublist(start, end));
+      new _BuiltList<E>.withSafeList(_list.sublist(start, end));
 
   /// As [List.getRange].
   Iterable<E> getRange(int start, int end) => _list.getRange(start, end);
@@ -212,10 +212,20 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
   // Internal.
 
-  BuiltList._copyAndCheck([Iterable iterable = const []])
-      : _list = new List<E>.from(iterable, growable: false) {
-    _checkGenericTypeParameter();
+  BuiltList._(this._list) {
+    if (E == dynamic) {
+      throw new UnsupportedError(
+          'explicit element type required, for example "new BuiltList<int>"');
+    }
+  }
+}
 
+/// Default implementation of the public [BuiltList] interface.
+class _BuiltList<E> extends BuiltList<E> {
+  _BuiltList.withSafeList(List<E> list) : super._(list);
+
+  _BuiltList.copyAndCheck([Iterable iterable = const []])
+      : super._(new List<E>.from(iterable, growable: false)) {
     for (final element in _list) {
       if (element is! E) {
         throw new ArgumentError('iterable contained invalid element: $element');
@@ -223,16 +233,5 @@ class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
     }
   }
 
-  BuiltList._withSafeList(this._list) {
-    _checkGenericTypeParameter();
-  }
-
-  bool _hasExactElementType(Type type) => E == type;
-
-  void _checkGenericTypeParameter() {
-    if (E == dynamic) {
-      throw new UnsupportedError(
-          'explicit element type required, for example "new BuiltList<int>"');
-    }
-  }
+  bool hasExactElementType(Type type) => E == type;
 }

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -13,7 +13,7 @@ part of built_collection.list;
 /// [Built Collection library documentation]
 /// (#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
+abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   final List<E> _list;
   int _hashCode;
 

--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -13,7 +13,7 @@ part of built_collection.list;
 /// for the general properties of Built Collections.
 class ListBuilder<E> {
   List<E> _list;
-  BuiltList<E> _listOwner;
+  _BuiltList<E> _listOwner;
 
   /// Instantiates with elements from an [Iterable].
   ///
@@ -34,7 +34,7 @@ class ListBuilder<E> {
   /// of `BuiltList`s.
   BuiltList<E> build() {
     if (_listOwner == null) {
-      _setOwner(new BuiltList<E>._withSafeList(_list));
+      _setOwner(new _BuiltList<E>.withSafeList(_list));
     }
     return _listOwner;
   }
@@ -46,7 +46,7 @@ class ListBuilder<E> {
 
   /// Replaces all elements with elements from an [Iterable].
   void replace(Iterable iterable) {
-    if (iterable is BuiltList<E>) {
+    if (iterable is _BuiltList<E>) {
       _setOwner(iterable);
     } else {
       _setSafeList(new List<E>.from(iterable));
@@ -219,7 +219,7 @@ class ListBuilder<E> {
     _checkGenericTypeParameter();
   }
 
-  void _setOwner(BuiltList<E> listOwner) {
+  void _setOwner(_BuiltList<E> listOwner) {
     _list = listOwner._list;
     _listOwner = listOwner;
   }

--- a/lib/src/list_multimap.dart
+++ b/lib/src/list_multimap.dart
@@ -16,11 +16,11 @@ part 'list_multimap/list_multimap_builder.dart';
 
 // Internal only, for testing.
 class OverriddenHashcodeBuiltListMultimap<K, V>
-    extends BuiltListMultimap<K, V> {
+    extends _BuiltListMultimap<K, V> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltListMultimap(map, this._overridenHashCode)
-      : super._copyAndCheck(map.keys, (k) => map[k]);
+      : super.copyAndCheck(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -14,7 +14,7 @@ part of built_collection.list_multimap;
 /// [Built Collection library documentation]
 /// (#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltListMultimap<K, V> {
+abstract class BuiltListMultimap<K, V> {
   final Map<K, BuiltList<V>> _map;
 
   // Precomputed.
@@ -38,13 +38,13 @@ class BuiltListMultimap<K, V> {
   ///
   /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltListMultimap([multimap = const {}]) {
-    if (multimap is BuiltListMultimap &&
-        multimap._hasExactKeyAndValueTypes(K, V)) {
+    if (multimap is _BuiltListMultimap &&
+        multimap.hasExactKeyAndValueTypes(K, V)) {
       return multimap as BuiltListMultimap<K, V>;
     } else if (multimap is Map ||
         multimap is ListMultimap ||
         multimap is BuiltListMultimap) {
-      return new BuiltListMultimap<K, V>._copyAndCheck(
+      return new _BuiltListMultimap<K, V>.copyAndCheck(
           multimap.keys, (k) => multimap[k]);
     } else {
       throw new ArgumentError(
@@ -176,27 +176,7 @@ class BuiltListMultimap<K, V> {
 
   // Internal.
 
-  BuiltListMultimap._copyAndCheck(Iterable keys, Function lookup)
-      : _map = new Map<K, BuiltList<V>>() {
-    _checkGenericTypeParameter();
-
-    for (final key in keys) {
-      if (key is K) {
-        _map[key] = new BuiltList<V>(lookup(key));
-      } else {
-        throw new ArgumentError('map contained invalid key: $key');
-      }
-    }
-  }
-
-  BuiltListMultimap._withSafeMap(this._map) {
-    _checkGenericTypeParameter();
-  }
-
-  bool _hasExactKeyAndValueTypes(Type key, Type value) =>
-      K == key && V == value;
-
-  void _checkGenericTypeParameter() {
+  BuiltListMultimap._(this._map) {
     if (K == dynamic) {
       throw new UnsupportedError('explicit key type required, '
           'for example "new BuiltListMultimap<int, int>"');
@@ -206,4 +186,22 @@ class BuiltListMultimap<K, V> {
           ' for example "new BuiltListMultimap<int, int>"');
     }
   }
+}
+
+/// Default implementation of the public [BuiltListMultimap] interface.
+class _BuiltListMultimap<K, V> extends BuiltListMultimap<K, V> {
+  _BuiltListMultimap.withSafeMap(Map<K, BuiltList<V>> map) : super._(map);
+
+  _BuiltListMultimap.copyAndCheck(Iterable keys, Function lookup)
+      : super._(new Map<K, BuiltList<V>>()) {
+    for (final key in keys) {
+      if (key is K) {
+        _map[key] = new BuiltList<V>(lookup(key));
+      } else {
+        throw new ArgumentError('map contained invalid key: $key');
+      }
+    }
+  }
+
+  bool hasExactKeyAndValueTypes(Type key, Type value) => K == key && V == value;
 }

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -17,7 +17,7 @@ class ListMultimapBuilder<K, V> {
   Map<K, BuiltList<V>> _builtMap;
   // Instance that _builtMap belongs to. If present, _builtMap must not be
   // mutated.
-  BuiltListMultimap<K, V> _builtMapOwner;
+  _BuiltListMultimap<K, V> _builtMapOwner;
   // ListBuilders for keys that are being changed.
   Map<K, ListBuilder<V>> _builderMap;
 
@@ -52,7 +52,7 @@ class ListMultimapBuilder<K, V> {
         }
       }
 
-      _builtMapOwner = new BuiltListMultimap<K, V>._withSafeMap(_builtMap);
+      _builtMapOwner = new _BuiltListMultimap<K, V>.withSafeMap(_builtMap);
     }
     return _builtMapOwner;
   }
@@ -65,7 +65,7 @@ class ListMultimapBuilder<K, V> {
   /// Replaces all elements with elements from a [Map], [ListMultimap] or
   /// [BuiltListMultimap].
   void replace(dynamic multimap) {
-    if (multimap is BuiltListMultimap<K, V>) {
+    if (multimap is _BuiltListMultimap<K, V>) {
       _setOwner(multimap);
     } else if (multimap is Map ||
         multimap is ListMultimap ||
@@ -185,7 +185,7 @@ class ListMultimapBuilder<K, V> {
     _checkGenericTypeParameter();
   }
 
-  void _setOwner(BuiltListMultimap<K, V> builtListMultimap) {
+  void _setOwner(_BuiltListMultimap<K, V> builtListMultimap) {
     _builtMapOwner = builtListMultimap;
     _builtMap = builtListMultimap._map;
     _builderMap = new Map<K, ListBuilder<V>>();

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -12,11 +12,11 @@ part 'map/built_map.dart';
 part 'map/map_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltMap<K, V> extends BuiltMap<K, V> {
+class OverriddenHashcodeBuiltMap<K, V> extends _BuiltMap<K, V> {
   final int _overrridenHashCode;
 
   OverriddenHashcodeBuiltMap(map, this._overrridenHashCode)
-      : super._copyAndCheck(map.keys, (k) => map[k]);
+      : super.copyAndCheck(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -13,7 +13,7 @@ part of built_collection.map;
 /// for the general properties of Built Collections.
 class MapBuilder<K, V> {
   Map<K, V> _map;
-  BuiltMap<K, V> _mapOwner;
+  _BuiltMap<K, V> _mapOwner;
 
   /// Instantiates with elements from a [Map] or [BuiltMap].
   ///
@@ -34,7 +34,7 @@ class MapBuilder<K, V> {
   /// of `BuiltMap`s.
   BuiltMap<K, V> build() {
     if (_mapOwner == null) {
-      _mapOwner = new BuiltMap<K, V>._withSafeMap(_map);
+      _mapOwner = new _BuiltMap<K, V>.withSafeMap(_map);
     }
     return _mapOwner;
   }
@@ -46,10 +46,10 @@ class MapBuilder<K, V> {
 
   /// Replaces all elements with elements from a [Map] or [BuiltMap].
   void replace(Object map) {
-    if (map is BuiltMap<K, V>) {
+    if (map is _BuiltMap<K, V>) {
       _setOwner(map);
     } else if (map is BuiltMap) {
-      _setSafeMap(new Map<K, V>.from(map._map));
+      _setSafeMap(new Map<K, V>.fromIterable(map.keys, value: (k) => map[k]));
     } else if (map is Map) {
       _setSafeMap(new Map<K, V>.from(map));
     } else {
@@ -115,7 +115,7 @@ class MapBuilder<K, V> {
     _checkGenericTypeParameter();
   }
 
-  void _setOwner(BuiltMap<K, V> mapOwner) {
+  void _setOwner(_BuiltMap<K, V> mapOwner) {
     _mapOwner = mapOwner;
     _map = mapOwner._map;
   }

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -15,11 +15,11 @@ part 'set/built_set.dart';
 part 'set/set_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltSet<T> extends BuiltSet<T> {
+class OverriddenHashcodeBuiltSet<T> extends _BuiltSet<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
-      : super._copyAndCheck(iterable);
+      : super.copyAndCheck(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -13,7 +13,7 @@ part of built_collection.set;
 /// See the
 /// [Built Collection library documentation](#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
+abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   final Set<E> _set;
   int _hashCode;
 
@@ -27,10 +27,10 @@ class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   ///
   /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltSet([Iterable iterable = const []]) {
-    if (iterable is BuiltSet && iterable._hasExactElementType(E)) {
+    if (iterable is _BuiltSet && iterable.hasExactElementType(E)) {
       return iterable as BuiltSet<E>;
     } else {
-      return new BuiltSet<E>._copyAndCheck(iterable);
+      return new _BuiltSet<E>.copyAndCheck(iterable);
     }
   }
 
@@ -99,18 +99,18 @@ class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
   /// As [Set.difference] but takes and returns a `BuiltSet<E>`.
   BuiltSet<E> difference(BuiltSet<Object> other) =>
-      new BuiltSet<E>._withSafeSet(_set.difference(other._set));
+      new _BuiltSet<E>.withSafeSet(_set.difference(other._set));
 
   /// As [Set.intersection] but takes and returns a `BuiltSet<E>`.
   BuiltSet<E> intersection(BuiltSet<Object> other) =>
-      new BuiltSet<E>._withSafeSet(_set.intersection(other._set));
+      new _BuiltSet<E>.withSafeSet(_set.intersection(other._set));
 
   /// As [Set.lookup].
   E lookup(Object object) => _set.lookup(object);
 
   /// As [Set.union] but takes and returns a `BuiltSet<E>`.
   BuiltSet<E> union(BuiltSet<E> other) =>
-      new BuiltSet<E>._withSafeSet(_set.union(other._set));
+      new _BuiltSet<E>.withSafeSet(_set.union(other._set));
 
   // Iterable.
 
@@ -205,9 +205,20 @@ class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
   // Internal.
 
-  BuiltSet._copyAndCheck([Iterable iterable = const []]) : _set = new Set<E>() {
-    _checkGenericTypeParameter();
+  BuiltSet._(this._set) {
+    if (E == dynamic) {
+      throw new UnsupportedError(
+          'explicit element type required, for example "new BuiltSet<int>"');
+    }
+  }
+}
 
+/// Default implementation of the public [BuiltSet] interface.
+class _BuiltSet<E> extends BuiltSet<E> {
+  _BuiltSet.withSafeSet(Set<E> set) : super._(set);
+
+  _BuiltSet.copyAndCheck([Iterable iterable = const []])
+      : super._(new Set<E>()) {
     for (final element in iterable) {
       if (element is E) {
         _set.add(element);
@@ -217,16 +228,5 @@ class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
     }
   }
 
-  BuiltSet._withSafeSet(this._set) {
-    _checkGenericTypeParameter();
-  }
-
-  bool _hasExactElementType(Type type) => E == type;
-
-  void _checkGenericTypeParameter() {
-    if (E == dynamic) {
-      throw new UnsupportedError(
-          'explicit element type required, for example "new BuiltSet<int>"');
-    }
-  }
+  bool hasExactElementType(Type type) => E == type;
 }

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -13,7 +13,7 @@ part of built_collection.set;
 /// for the general properties of Built Collections.
 class SetBuilder<E> {
   Set<E> _set;
-  BuiltSet<E> _setOwner;
+  _BuiltSet<E> _setOwner;
 
   /// Instantiates with elements from an [Iterable].
   ///
@@ -34,7 +34,7 @@ class SetBuilder<E> {
   /// of `BuiltSet`s.
   BuiltSet<E> build() {
     if (_setOwner == null) {
-      _setOwner = new BuiltSet<E>._withSafeSet(_set);
+      _setOwner = new _BuiltSet<E>.withSafeSet(_set);
     }
     return _setOwner;
   }
@@ -46,7 +46,7 @@ class SetBuilder<E> {
 
   /// Replaces all elements with elements from an [Iterable].
   void replace(Iterable iterable) {
-    if (iterable is BuiltSet<E>) {
+    if (iterable is _BuiltSet<E>) {
       _withOwner(iterable);
     } else {
       // Can't use addAll because it requires an Iterable<E>.
@@ -158,7 +158,7 @@ class SetBuilder<E> {
     _checkGenericTypeParameter();
   }
 
-  void _withOwner(BuiltSet<E> setOwner) {
+  void _withOwner(_BuiltSet<E> setOwner) {
     _set = setOwner._set;
     _setOwner = setOwner;
   }

--- a/lib/src/set_multimap.dart
+++ b/lib/src/set_multimap.dart
@@ -15,11 +15,11 @@ part 'set_multimap/built_set_multimap.dart';
 part 'set_multimap/set_multimap_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
+class OverriddenHashcodeBuiltSetMultimap<K, V> extends _BuiltSetMultimap<K, V> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltSetMultimap(map, this._overridenHashCode)
-      : super._copyAndCheck(map.keys, (k) => map[k]);
+      : super.copyAndCheck(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -13,7 +13,7 @@ part of built_collection.set_multimap;
 /// See the
 /// [Built Collection library documentation](#built_collection/built_collection)
 /// for the general properties of Built Collections.
-class BuiltSetMultimap<K, V> {
+abstract class BuiltSetMultimap<K, V> {
   final Map<K, BuiltSet<V>> _map;
 
   // Precomputed.
@@ -37,13 +37,13 @@ class BuiltSetMultimap<K, V> {
   ///
   /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltSetMultimap([multimap = const {}]) {
-    if (multimap is BuiltSetMultimap &&
-        multimap._hasExactKeyAndValueTypes(K, V)) {
+    if (multimap is _BuiltSetMultimap &&
+        multimap.hasExactKeyAndValueTypes(K, V)) {
       return multimap as BuiltSetMultimap<K, V>;
     } else if (multimap is Map ||
         multimap is SetMultimap ||
         multimap is BuiltSetMultimap) {
-      return new BuiltSetMultimap<K, V>._copyAndCheck(
+      return new _BuiltSetMultimap<K, V>.copyAndCheck(
           multimap.keys, (k) => multimap[k]);
     } else {
       throw new ArgumentError('expected Map, SetMultimap or BuiltSetMultimap, '
@@ -174,27 +174,7 @@ class BuiltSetMultimap<K, V> {
 
   // Internal.
 
-  BuiltSetMultimap._copyAndCheck(Iterable keys, Function lookup)
-      : _map = new Map<K, BuiltSet<V>>() {
-    _checkGenericTypeParameter();
-
-    for (final key in keys) {
-      if (key is K) {
-        _map[key] = new BuiltSet<V>(lookup(key));
-      } else {
-        throw new ArgumentError('map contained invalid key: $key');
-      }
-    }
-  }
-
-  BuiltSetMultimap._withSafeMap(this._map) {
-    _checkGenericTypeParameter();
-  }
-
-  bool _hasExactKeyAndValueTypes(Type key, Type value) =>
-      K == key && V == value;
-
-  void _checkGenericTypeParameter() {
+  BuiltSetMultimap._(this._map) {
     if (K == dynamic) {
       throw new UnsupportedError('explicit key type required, '
           'for example "new BuiltSetMultimap<int, int>"');
@@ -204,4 +184,22 @@ class BuiltSetMultimap<K, V> {
           ' for example "new BuiltSetMultimap<int, int>"');
     }
   }
+}
+
+/// Default implementation of the public [BuiltSetMultimap] interface.
+class _BuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
+  _BuiltSetMultimap.withSafeMap(Map<K, BuiltSet<V>> map) : super._(map);
+
+  _BuiltSetMultimap.copyAndCheck(Iterable keys, Function lookup)
+      : super._(new Map<K, BuiltSet<V>>()) {
+    for (final key in keys) {
+      if (key is K) {
+        _map[key] = new BuiltSet<V>(lookup(key));
+      } else {
+        throw new ArgumentError('map contained invalid key: $key');
+      }
+    }
+  }
+
+  bool hasExactKeyAndValueTypes(Type key, Type value) => K == key && V == value;
 }

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -17,7 +17,7 @@ class SetMultimapBuilder<K, V> {
   Map<K, BuiltSet<V>> _builtMap;
   // Instance that _builtMap belongs to. If present, _builtMap must not be
   // mutated.
-  BuiltSetMultimap<K, V> _builtMapOwner;
+  _BuiltSetMultimap<K, V> _builtMapOwner;
   // SetBuilders for keys that are being changed.
   Map<K, SetBuilder<V>> _builderMap;
 
@@ -52,7 +52,7 @@ class SetMultimapBuilder<K, V> {
         }
       }
 
-      _builtMapOwner = new BuiltSetMultimap<K, V>._withSafeMap(_builtMap);
+      _builtMapOwner = new _BuiltSetMultimap<K, V>.withSafeMap(_builtMap);
     }
     return _builtMapOwner;
   }
@@ -65,7 +65,7 @@ class SetMultimapBuilder<K, V> {
   /// Replaces all elements with elements from a [Map], [SetMultimap] or
   /// [BuiltSetMultimap].
   void replace(dynamic multimap) {
-    if (multimap is BuiltSetMultimap<K, V>) {
+    if (multimap is _BuiltSetMultimap<K, V>) {
       _setOwner(multimap);
     } else if (multimap is Map ||
         multimap is SetMultimap ||
@@ -184,7 +184,7 @@ class SetMultimapBuilder<K, V> {
     _checkGenericTypeParameter();
   }
 
-  void _setOwner(BuiltSetMultimap<K, V> builtSetMultimap) {
+  void _setOwner(_BuiltSetMultimap<K, V> builtSetMultimap) {
     _builtMapOwner = builtSetMultimap;
     _builtMap = builtSetMultimap._map;
     _builderMap = new Map<K, SetBuilder<V>>();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ description: >
 authors:
 - David Morgan <davidmorgan@google.com>
 - Matan Lurey <matanl@google.com>
+- Philipp Schiffmann <philippschiffmann93@gmail.com>
 homepage: https://github.com/google/built_collection.dart
 
 environment:


### PR DESCRIPTION
Does this look good to you, or do you have any preferences regarding the renaming or placement of functions etc? I'm quite picky myself when it comes to style and consistency, but since style is subjective and it's your package, I'm very open to criticism :-)
I'm unsure about `operator==`: Should I move it to the subclass, since I check for the subclass type? If yes, should I move `hashCode` too?

But if you think this is heading in right general direction, I can change the other classes too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/113)
<!-- Reviewable:end -->
