### PR TITLE
Update implementors of Iterable, List, and Set to declare new methods.

### DIFF
--- a/lib/src/internal/copy_on_write_list.dart
+++ b/lib/src/internal/copy_on_write_list.dart
@@ -20,10 +20,24 @@ class CopyOnWriteList<E> implements List<E> {
   E operator [](int index) => _list[index];
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<E> operator +(List<E> other) {
+    throw new UnimplementedError("+");
+  }
+
+  @override
   bool any(bool test(E element)) => _list.any(test);
 
   @override
   Map<int, E> asMap() => _list.asMap();
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
 
   @override
   bool contains(Object element) => _list.contains(element);
@@ -41,12 +55,27 @@ class CopyOnWriteList<E> implements List<E> {
   E get first => _list.first;
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set first(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = value;
+  }
+
+  @override
   E firstWhere(bool test(E element), {E orElse()}) =>
       _list.firstWhere(test, orElse: orElse);
 
   @override
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _list.fold(initialValue, combine);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError("followedBy");
+  }
 
   @override
   void forEach(void f(E element)) => _list.forEach(f);
@@ -56,6 +85,13 @@ class CopyOnWriteList<E> implements List<E> {
 
   @override
   int indexOf(E element, [int start = 0]) => _list.indexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(E element), [int start = 0]) {
+    throw new UnimplementedError("indexWhere");
+  }
 
   @override
   bool get isEmpty => _list.isEmpty;
@@ -73,7 +109,22 @@ class CopyOnWriteList<E> implements List<E> {
   E get last => _list.last;
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set last(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = value;
+  }
+
+  @override
   int lastIndexOf(E element, [int start]) => _list.lastIndexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(E element), [int start]) {
+    throw new UnimplementedError("lastIndexWhere");
+  }
 
   @override
   E lastWhere(bool test(E element), {E orElse()}) =>
@@ -86,13 +137,23 @@ class CopyOnWriteList<E> implements List<E> {
   E reduce(E combine(E value, E element)) => _list.reduce(combine);
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   Iterable<E> get reversed => _list.reversed;
 
   @override
   E get single => _list.single;
 
   @override
-  E singleWhere(bool test(E element)) => _list.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    return _list.singleWhere(test);
+  }
 
   @override
   Iterable<E> skip(int count) => _list.skip(count);
@@ -117,6 +178,13 @@ class CopyOnWriteList<E> implements List<E> {
 
   @override
   Iterable<E> where(bool test(E element)) => _list.where(test);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
 
   // Mutating methods: copy first if needed.
 

--- a/lib/src/internal/copy_on_write_list.dart
+++ b/lib/src/internal/copy_on_write_list.dart
@@ -23,7 +23,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<E> operator +(List<E> other) {
-    throw new UnimplementedError("+");
+    throw new UnimplementedError('+');
   }
 
   @override
@@ -36,7 +36,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('cast');
   }
 
   @override
@@ -74,7 +74,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
-    throw new UnimplementedError("followedBy");
+    throw new UnimplementedError('followedBy');
   }
 
   @override
@@ -90,7 +90,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   int indexWhere(bool test(E element), [int start = 0]) {
-    throw new UnimplementedError("indexWhere");
+    throw new UnimplementedError('indexWhere');
   }
 
   @override
@@ -123,7 +123,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   int lastIndexWhere(bool test(E element), [int start]) {
-    throw new UnimplementedError("lastIndexWhere");
+    throw new UnimplementedError('lastIndexWhere');
   }
 
   @override
@@ -140,7 +140,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> retype<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('retype');
   }
 
   @override
@@ -151,7 +151,7 @@ class CopyOnWriteList<E> implements List<E> {
 
   @override
   E singleWhere(bool test(E element), {E orElse()}) {
-    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
     return _list.singleWhere(test);
   }
 
@@ -183,7 +183,7 @@ class CopyOnWriteList<E> implements List<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError("whereType");
+    throw new UnimplementedError('whereType');
   }
 
   // Mutating methods: copy first if needed.

--- a/lib/src/internal/copy_on_write_map.dart
+++ b/lib/src/internal/copy_on_write_map.dart
@@ -18,7 +18,7 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('cast');
   }
 
   @override
@@ -33,7 +33,7 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   Iterable<Null> get entries {
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
-    throw new UnimplementedError("entries");
+    throw new UnimplementedError('entries');
   }
 
   @override
@@ -57,14 +57,14 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
-    throw new UnimplementedError("map");
+    throw new UnimplementedError('map');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Map<K2, V2> retype<K2, V2>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('retype');
   }
 
   @override
@@ -90,7 +90,7 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   void addEntries(Iterable<Object> entries) {
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
-    throw new UnimplementedError("addEntries");
+    throw new UnimplementedError('addEntries');
   }
 
   @override
@@ -115,7 +115,7 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
-    throw new UnimplementedError("removeWhere");
+    throw new UnimplementedError('removeWhere');
   }
 
   @override
@@ -125,14 +125,14 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   V update(K key, V update(V value), {V ifAbsent()}) {
-    throw new UnimplementedError("update");
+    throw new UnimplementedError('update');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   void updateAll(V update(K key, V value)) {
-    throw new UnimplementedError("updateAll");
+    throw new UnimplementedError('updateAll');
   }
 
   // Internal.

--- a/lib/src/internal/copy_on_write_map.dart
+++ b/lib/src/internal/copy_on_write_map.dart
@@ -15,10 +15,26 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   V operator [](Object key) => _map[key];
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   bool containsKey(Object key) => _map.containsKey(key);
 
   @override
   bool containsValue(Object value) => _map.containsValue(value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("entries");
+  }
 
   @override
   void forEach(void f(K key, V value)) => _map.forEach(f);
@@ -36,6 +52,22 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   int get length => _map.length;
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("map");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   Iterable<V> get values => _map.values;
 
   // Mutating methods: copy first if needed.
@@ -50,6 +82,15 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   void addAll(Map<K, V> other) {
     _maybeCopyBeforeWrite();
     _map.addAll(other);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("addEntries");
   }
 
   @override
@@ -71,7 +112,28 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
   }
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError("removeWhere");
+  }
+
+  @override
   String toString() => _map.toString();
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError("update");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError("updateAll");
+  }
 
   // Internal.
 

--- a/lib/src/internal/copy_on_write_set.dart
+++ b/lib/src/internal/copy_on_write_set.dart
@@ -36,7 +36,7 @@ class CopyOnWriteSet<E> implements Set<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('cast');
   }
 
   @override
@@ -66,7 +66,7 @@ class CopyOnWriteSet<E> implements Set<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
-    throw new UnimplementedError("followedBy");
+    throw new UnimplementedError('followedBy');
   }
 
   @override
@@ -101,7 +101,7 @@ class CopyOnWriteSet<E> implements Set<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Set<T> retype<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('retype');
   }
 
   @override
@@ -109,7 +109,7 @@ class CopyOnWriteSet<E> implements Set<E> {
 
   @override
   E singleWhere(bool test(E element), {E orElse()}) {
-    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
     return _set.singleWhere(test);
   }
 
@@ -138,7 +138,7 @@ class CopyOnWriteSet<E> implements Set<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError("whereType");
+    throw new UnimplementedError('whereType');
   }
 
   // Mutating methods: copy first if needed.

--- a/lib/src/internal/copy_on_write_set.dart
+++ b/lib/src/internal/copy_on_write_set.dart
@@ -33,6 +33,13 @@ class CopyOnWriteSet<E> implements Set<E> {
   bool any(bool test(E element)) => _set.any(test);
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   bool contains(Object element) => _set.contains(element);
 
   @override
@@ -54,6 +61,13 @@ class CopyOnWriteSet<E> implements Set<E> {
   @override
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _set.fold(initialValue, combine);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError("followedBy");
+  }
 
   @override
   void forEach(void f(E element)) => _set.forEach(f);
@@ -84,10 +98,20 @@ class CopyOnWriteSet<E> implements Set<E> {
   E reduce(E combine(E value, E element)) => _set.reduce(combine);
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   E get single => _set.single;
 
   @override
-  E singleWhere(bool test(E element)) => _set.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    return _set.singleWhere(test);
+  }
 
   @override
   Iterable<E> skip(int count) => _set.skip(count);
@@ -109,6 +133,13 @@ class CopyOnWriteSet<E> implements Set<E> {
 
   @override
   Iterable<E> where(bool test(E element)) => _set.where(test);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
 
   // Mutating methods: copy first if needed.
 

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -130,6 +130,13 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   Iterable<E> where(bool test(E element)) => _list.where(test);
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
+
+  @override
   Iterable<T> expand<T>(Iterable<T> f(E e)) => _list.expand(f);
 
   @override
@@ -144,6 +151,13 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   @override
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       _list.fold(initialValue, combine);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError("followedBy");
+  }
 
   @override
   bool every(bool test(E element)) => _list.every(test);
@@ -205,10 +219,64 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
       _list.lastWhere(test, orElse: orElse);
 
   @override
-  E singleWhere(bool test(E element)) => _list.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    return _list.singleWhere(test);
+  }
 
   @override
   E elementAt(int index) => _list.elementAt(index);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<E> operator +(List<E> other) {
+    throw new UnimplementedError("+");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(E element), [int start = 0]) {
+    throw new UnimplementedError("indexWhere");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(E element), [int start]) {
+    throw new UnimplementedError("lastIndexWhere");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set first(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = value;
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set last(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = value;
+  }
 
   // Internal.
 

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -133,7 +133,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError("whereType");
+    throw new UnimplementedError('whereType');
   }
 
   @override
@@ -156,7 +156,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
-    throw new UnimplementedError("followedBy");
+    throw new UnimplementedError('followedBy');
   }
 
   @override
@@ -220,7 +220,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
   @override
   E singleWhere(bool test(E element), {E orElse()}) {
-    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
     return _list.singleWhere(test);
   }
 
@@ -231,35 +231,35 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('cast');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> retype<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('retype');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<E> operator +(List<E> other) {
-    throw new UnimplementedError("+");
+    throw new UnimplementedError('+');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   int indexWhere(bool test(E element), [int start = 0]) {
-    throw new UnimplementedError("indexWhere");
+    throw new UnimplementedError('indexWhere');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   int lastIndexWhere(bool test(E element), [int start]) {
-    throw new UnimplementedError("lastIndexWhere");
+    throw new UnimplementedError('lastIndexWhere');
   }
 
   @override

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -122,28 +122,28 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('cast');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   List<T> retype<T>() {
-    throw new UnimplementedError("cast");
+    throw new UnimplementedError('retype');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<E> followedBy(Iterable<E> other) {
-    throw new UnimplementedError("followedBy");
+    throw new UnimplementedError('followedBy');
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError("whereType");
+    throw new UnimplementedError('whereType');
   }
 
   @override
@@ -228,7 +228,7 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
   @override
   E singleWhere(bool test(E element), {E orElse()}) {
-    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    if (orElse != null) throw new UnimplementedError('singleWhere:orElse');
     return _set.singleWhere(test);
   }
 

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -119,6 +119,34 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   Iterator<E> get iterator => _set.iterator;
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError("followedBy");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
+
+  @override
   Iterable<T> map<T>(T f(E e)) => _set.map(f);
 
   @override
@@ -199,7 +227,10 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
       _set.lastWhere(test, orElse: orElse);
 
   @override
-  E singleWhere(bool test(E element)) => _set.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    return _set.singleWhere(test);
+  }
 
   @override
   E elementAt(int index) => _set.elementAt(index);


### PR DESCRIPTION
These new methods will need to be found on implementors in Dart 2.0:
https://gist.github.com/lrhn/b99fe5f73a10b3b1a91579853056d08b

I left everything as unimplemented. I tried to put methods in alphabetical
order, but BuiltList and BuiltSet were in an order that I could not grok.

Feel free to add edits implementing or sorting methods, or comment and I can do some of it. Anything more-than-trivial should probably not be done by me. This just lets a Dart 2.0 user use this package before the package properly implements the new methods, which may or may not take time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/119)
<!-- Reviewable:end -->
