### PR TITLE
Don't test result of void functions, which is disallowed in dart 2

### DIFF
--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -242,21 +242,18 @@ void main() {
     test('has a method like List.remove that returns nothing', () {
       expect((new ListBuilder<int>([1, 2])..remove(2)).build(), [1]);
       expect((new BuiltList<int>([1, 2]).toBuilder()..remove(2)).build(), [1]);
-      expect(new ListBuilder<int>([1, 2]).remove(2), isNull);
     });
 
     test('has a method like List.removeAt that returns nothing', () {
       expect((new ListBuilder<int>([1, 2])..removeAt(1)).build(), [1]);
       expect(
           (new BuiltList<int>([1, 2]).toBuilder()..removeAt(1)).build(), [1]);
-      expect(new ListBuilder<int>([1, 2]).removeAt(0), isNull);
     });
 
     test('has a method like List.removeLast that returns nothing', () {
       expect((new ListBuilder<int>([1, 2])..removeLast()).build(), [1]);
       expect(
           (new BuiltList<int>([1, 2]).toBuilder()..removeLast()).build(), [1]);
-      expect(new ListBuilder<int>([1, 2]).removeLast(), isNull);
     });
 
     test('has a method like List.removeWhere', () {

--- a/test/list_multimap/list_multimap_builder_test.dart
+++ b/test/list_multimap/list_multimap_builder_test.dart
@@ -360,12 +360,6 @@ void main() {
             1: ['1'],
             2: ['2']
           });
-      expect(
-          new ListMultimapBuilder<int, String>({
-            1: ['1'],
-            2: ['2', '3']
-          }).remove(2, '3'),
-          isNull);
     });
 
     test('has a method like ListMultimap.removeAll that returns nothing', () {
@@ -391,12 +385,6 @@ void main() {
           {
             1: ['1']
           });
-      expect(
-          new ListMultimapBuilder<int, String>({
-            1: ['1'],
-            2: ['2', '3']
-          }).removeAll(2),
-          isNull);
     });
 
     test('has a method like ListMultimap.clear', () {

--- a/test/map/map_builder_test.dart
+++ b/test/map/map_builder_test.dart
@@ -186,8 +186,6 @@ void main() {
               .build()
               .toMap(),
           {1: '1', 2: '2'});
-      expect(new MapBuilder<int, String>({1: '1'}).putIfAbsent(1, () => '3'),
-          isNull);
     });
 
     test('has a method like Map.addAll', () {
@@ -214,7 +212,6 @@ void main() {
               .build()
               .toMap(),
           {1: '1'});
-      expect(new MapBuilder<int, String>({1: '1'}).remove(1), isNull);
     });
 
     test('has a method like Map.clear', () {

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -148,7 +148,6 @@ void main() {
     test('has a method like Set.remove that returns nothing', () {
       expect((new SetBuilder<int>([1, 2])..remove(2)).build(), [1]);
       expect((new BuiltSet<int>([1, 2]).toBuilder()..remove(2)).build(), [1]);
-      expect(new SetBuilder<int>([1, 2]).remove(2), isNull);
     });
 
     test('has a method like Set.removeAll', () {

--- a/test/set_multimap/set_multimap_builder_test.dart
+++ b/test/set_multimap/set_multimap_builder_test.dart
@@ -356,12 +356,6 @@ void main() {
             1: ['1'],
             2: ['2']
           });
-      expect(
-          new SetMultimapBuilder<int, String>({
-            1: ['1'],
-            2: ['2', '3']
-          }).remove(2, '3'),
-          isNull);
     });
 
     test('has a method like SetMultimap.removeAll that returns nothing', () {
@@ -387,12 +381,6 @@ void main() {
           {
             1: ['1']
           });
-      expect(
-          new SetMultimapBuilder<int, String>({
-            1: ['1'],
-            2: ['2', '3']
-          }).removeAll(2),
-          isNull);
     });
 
     test('has a method like SetMultimap.clear', () {


### PR DESCRIPTION
This is almost certain to be disallowed in dart 2. Future-proof it by
removing these test cases.

The good news is that dart 2 will come with better guarantees that the
results of void methods aren't used by anyone, so the tests should be
less (or completely un) necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/130)
<!-- Reviewable:end -->
