### PR TITLE
Add .dart_tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 pubspec.lock
 packages
+.dart_tool
 .idea
 .packages
 .pub


### PR DESCRIPTION
The .dart_tool directory is the new canonical location for cache/temp
files for Dart-related tooling.