### PR TITLE
Dart 2.0 cast functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+PATCH
+- Implement cast functions in BuiltList and BuildSet
 # Changelog
 
 ## 3.1.1

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -224,15 +224,15 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   E elementAt(int index) => _list.elementAt(index);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltList<T> cast<T>() {
-    return new _BuiltList.withSafeList(_list.cast<T>());
+    if (T == E) {
+      return this as BuiltList<T>;
+    } else {
+      return new _BuiltList<T>.withSafeList(_list.cast<T>());
+    }
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltList<T> retype<T>() => cast<T>();
 
   // Internal.

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -227,15 +227,13 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltList<T> cast<T>() {
-    throw new UnimplementedError('cast');
+    return new _BuiltList.withSafeList(_list.cast<T>());
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  BuiltList<T> retype<T>() {
-    throw new UnimplementedError('retype');
-  }
+  BuiltList<T> retype<T>() => cast<T>();
 
   // Internal.
 

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -232,9 +232,6 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
     }
   }
 
-  @override
-  BuiltList<T> retype<T>() => cast<T>();
-
   // Internal.
 
   BuiltList._(this._list) {

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -121,15 +121,16 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   Iterator<E> get iterator => _set.iterator;
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltSet<T> cast<T>() {
-    return new _BuiltSet<T>.withSafeSet(() => _setFactory().cast<T>(), _set.cast<T>());
+    if (T == E) {
+      return this as BuiltSet<T>;
+    } else {
+      return new _BuiltSet<T>.withSafeSet(() => _setFactory().cast<T>(),
+          _set.cast<T>());
+    }
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltSet<T> retype<T>() {
     return cast<T>();
   }

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -131,11 +131,6 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   }
 
   @override
-  BuiltSet<T> retype<T>() {
-    return cast<T>();
-  }
-
-  @override
   Iterable<E> followedBy(Iterable<E> other) => _set.followedBy(other);
 
   @override

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -124,14 +124,14 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltSet<T> cast<T>() {
-    throw new UnimplementedError('cast');
+    return new _BuiltSet<T>.withSafeSet(() => _setFactory().cast<T>(), _set.cast<T>());
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltSet<T> retype<T>() {
-    throw new UnimplementedError('retype');
+    return cast<T>();
   }
 
   @override
@@ -141,7 +141,7 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError('whereType');
+    return _set.whereType<T>();
   }
 
   @override


### PR DESCRIPTION
Hello,

I've made quick implementation for cast functions in BuiltList and BuiltSet classes.

They work fine with --preview-dart-2 flag, but without the flag, they don't, mainly because Dart 1 doesn't handle generic functions as generic functions:
```
class A<E> {
  void functionName<T>() {
    print(T.toString());    // without --preview-dart-2 it always outputs "dynamic"
  }
}
```

I didn't follow SDK way to implement CastList and CastSet classes because BuiltList is already a wrapper around List, and CastBuiltList class (SDK-like) is nothing more than unnecessary overhead.

Please review.

Regards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/148)
<!-- Reviewable:end -->
