### PR TITLE
Cast functions implemented for BuiltList and BuiltSet

### DIFF
--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -227,15 +227,13 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltList<T> cast<T>() {
-    throw new UnimplementedError('cast');
+    return new _BuiltList.withSafeList(_list.cast<T>());
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  BuiltList<T> retype<T>() {
-    throw new UnimplementedError('retype');
-  }
+  BuiltList<T> retype<T>() => cast<T>();
 
   // Internal.
 

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -224,16 +224,9 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   E elementAt(int index) => _list.elementAt(index);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltList<T> cast<T>() {
-    return new _BuiltList.withSafeList(_list.cast<T>());
+    return new _BuiltList<T>.withSafeList(_list.cast<T>());
   }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  BuiltList<T> retype<T>() => cast<T>();
 
   // Internal.
 

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -121,17 +121,8 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   Iterator<E> get iterator => _set.iterator;
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   BuiltSet<T> cast<T>() {
     return new _BuiltSet<T>.withSafeSet(() => _setFactory().cast<T>(), _set.cast<T>());
-  }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  BuiltSet<T> retype<T>() {
-    return cast<T>();
   }
 
   @override

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -124,14 +124,14 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltSet<T> cast<T>() {
-    throw new UnimplementedError('cast');
+    return new _BuiltSet<T>.withSafeSet(() => _setFactory().cast<T>(), _set.cast<T>());
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   BuiltSet<T> retype<T>() {
-    throw new UnimplementedError('retype');
+    return cast<T>();
   }
 
   @override
@@ -141,7 +141,7 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
-    throw new UnimplementedError('whereType');
+    return _set.whereType<T>();
   }
 
   @override


### PR DESCRIPTION
Hello,

I've made quick implementation for cast functions in BuiltList and BuiltSet classes.

They work fine with --preview-dart-2 flag, but without the flag, they don't, mainly because Dart 1 doesn't handle generic functions as generic functions:

class A<E> {
  void functionName<T>() {
    print(T.toString());    // without --preview-dart-2 it always outputs "dynamic"
  }
}
I didn't follow SDK way to implement CastList and CastSet classes because BuiltList is already a wrapper around List, and CastBuiltList class (SDK-like) is nothing more than unnecessary overhead.

Please review.

Regards
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/149)
<!-- Reviewable:end -->
