### PR TITLE
Added length, isEmpty, and isNotEmpty getters to builders. 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 David Morgan/Google Inc. <davidmorgan@google.com>
 Matan Lurey/Google Inc. <matanl@google.com>
 Philipp Schiffmann <philippschiffmann93@gmail.com>
+Andrew Babin <code@andrewbab.in>

--- a/AUTHORS
+++ b/AUTHORS
@@ -3,7 +3,7 @@
 #
 #   Name/Organization <email address>
 
+Andrew Babin <code@andrewbab.in>
 David Morgan/Google Inc. <davidmorgan@google.com>
 Matan Lurey/Google Inc. <matanl@google.com>
 Philipp Schiffmann <philippschiffmann93@gmail.com>
-Andrew Babin <code@andrewbab.in>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0 (unreleased)
+
+- Add length, isEmpty and isNotEmpty to ListBuilder, MapBuilder and SetBuilder
+
 ## 3.1.3
 
 - Allow SDK 2.0.0.

--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -64,6 +64,15 @@ class ListBuilder<E> {
     _safeList[index] = element;
   }
 
+  /// As [List.length].
+  int get length => _list.length;
+  
+  /// As [List.isEmpty].
+  bool get isEmpty => _list.isEmpty;
+  
+  /// As [List.isNotEmpty].
+  bool get isNotEmpty => _list.isNotEmpty;
+
   /// As [List.add].
   void add(E value) {
     _checkElement(value);

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -123,6 +123,15 @@ class MapBuilder<K, V> {
     _safeMap[key] = value;
   }
 
+  /// As [Map.length].
+  int get length => _map.length;
+
+  /// As [Map.isEmpty].
+  bool get isEmpty => _map.isEmpty;
+  
+  /// As [Map.isNotEmpty].
+  bool get isNotEmpty => _map.isNotEmpty;
+
   /// As [Map.putIfAbsent] but returns nothing.
   void putIfAbsent(K key, V ifAbsent()) {
     _checkKey(key);

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -98,6 +98,15 @@ class SetBuilder<E> {
 
   // Based on Set.
 
+  /// As [Set.length].
+  int get length => _set.length;
+
+  /// As [Set.isEmpty].
+  bool get isEmpty => _set.isEmpty;
+  
+  /// As [Set.isNotEmpty].
+  bool get isNotEmpty => _set.isNotEmpty;
+
   /// As [Set.add].
   void add(E value) {
     _checkElement(value);

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -176,11 +176,20 @@ void main() {
       expect(new BuiltList<int>().toBuilder().length, 0);
     });
              
-    test('has methods like List.isEmpty and List.isNotEmpty', () {
-      final listBuilderA = new ListBuilder<int>([]);
-      final listBuilderB = new BuiltList<int>([]).toBuilder();
-      expect(listBuilderA.isEmpty, !listBuilderA.isNotEmpty);
-      expect(listBuilderB.isEmpty, !listBuilderB.isNotEmpty);
+    test('has a method like List.isEmpty', () {
+      expect(new ListBuilder<int>([1, 2]).isEmpty, false);
+      expect(new BuiltList<int>([1, 2]).toBuilder().isEmpty, false);
+             
+      expect(new ListBuilder<int>().isEmpty, true);
+      expect(new BuiltList<int>().toBuilder().isEmpty, true);
+    });
+
+    test('has a method like List.isNotEmpty', () {
+      expect(new ListBuilder<int>([1, 2]).isNotEmpty, true);
+      expect(new BuiltList<int>([1, 2]).toBuilder().isNotEmpty, true);
+             
+      expect(new ListBuilder<int>().isNotEmpty, false);
+      expect(new BuiltList<int>().toBuilder().isNotEmpty, false);
     });
 
     test('has a method like List.add', () {

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -176,20 +176,11 @@ void main() {
       expect(new BuiltList<int>().toBuilder().length, 0);
     });
              
-    test('has a method like List.isEmpty', () {
-      expect(new ListBuilder<int>([1, 2]).isEmpty, false);
-      expect(new BuiltList<int>([1, 2]).toBuilder().isEmpty, false);
-             
-      expect(new ListBuilder<int>().isEmpty, true);
-      expect(new BuiltList<int>().toBuilder().isEmpty, true);
-    });
-             
-    test('has a method like List.isNotEmpty', () {
-      expect(new ListBuilder<int>([1, 2]).isNotEmpty, true);
-      expect(new BuiltList<int>([1, 2]).toBuilder().isNotEmpty, true);
-             
-      expect(new ListBuilder<int>().isNotEmpty, false);
-      expect(new BuiltList<int>().toBuilder().isNotEmpty, false);
+    test('has methods like List.isEmpty and List.isNotEmpty', () {
+      final listBuilderA = new ListBuilder<int>([]);
+      final listBuilderB = new BuiltList<int>([]).toBuilder();
+      expect(listBuilderA.isEmpty, !listBuilderA.isNotEmpty);
+      expect(listBuilderB.isEmpty, !listBuilderB.isNotEmpty);
     });
 
     test('has a method like List.add', () {

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -168,6 +168,30 @@ void main() {
       expect((new BuiltList<int>([1]).toBuilder()..[0] = 2).build(), [2]);
     });
 
+    test('has a method like List.length', () {
+      expect(new ListBuilder<int>([1, 2]).length, 2);
+      expect(new BuiltList<int>([1, 2]).toBuilder().length, 2);
+             
+      expect(new ListBuilder<int>().length, 0);
+      expect(new BuiltList<int>().toBuilder().length, 0);
+    });
+             
+    test('has a method like List.isEmpty', () {
+      expect(new ListBuilder<int>([1, 2]).isEmpty, false);
+      expect(new BuiltList<int>([1, 2]).toBuilder().isEmpty, false);
+             
+      expect(new ListBuilder<int>().isEmpty, true);
+      expect(new BuiltList<int>().toBuilder().isEmpty, true);
+    });
+             
+    test('has a method like List.isNotEmpty', () {
+      expect(new ListBuilder<int>([1, 2]).isNotEmpty, true);
+      expect(new BuiltList<int>([1, 2]).toBuilder().isNotEmpty, true);
+             
+      expect(new ListBuilder<int>().isNotEmpty, false);
+      expect(new BuiltList<int>().toBuilder().isNotEmpty, false);
+    });
+
     test('has a method like List.add', () {
       expect((new ListBuilder<int>()..add(1)).build(), [1]);
       expect((new BuiltList<int>().toBuilder()..add(1)).build(), [1]);

--- a/test/map/map_builder_test.dart
+++ b/test/map/map_builder_test.dart
@@ -180,6 +180,21 @@ void main() {
           {1: '1', 2: '2'});
     });
 
+    test('has a method like Map.length', () {
+      expect(new MapBuilder<int, String>({1: '1', 2: '2'}).length, 2);
+      expect(new BuiltMap<int, String>({1: '1', 2: '2'}).toBuilder().length, 2);
+      
+      expect(new MapBuilder<int, String>({}).length, 0);
+      expect(new BuiltMap<int, String>({}).toBuilder().length, 0);
+    });
+
+    test('has methods like Map.isEmpty and Map.isNotEmpty', () {
+      final mapBuilderA = new MapBuilder<int, String>({1: '1', 2: '2'});
+      final mapBuilderB = new BuiltMap<int, String>({1: '1', 2: '2'}).toBuilder();
+      expect(mapBuilderA.isEmpty, !mapBuilderA.isNotEmpty);
+      expect(mapBuilderB.isEmpty, !mapBuilderB.isNotEmpty);
+    });
+
     test('has a method like Map.putIfAbsent that returns nothing', () {
       expect(
           (new MapBuilder<int, String>({1: '1'})

--- a/test/map/map_builder_test.dart
+++ b/test/map/map_builder_test.dart
@@ -188,11 +188,20 @@ void main() {
       expect(new BuiltMap<int, String>({}).toBuilder().length, 0);
     });
 
-    test('has methods like Map.isEmpty and Map.isNotEmpty', () {
-      final mapBuilderA = new MapBuilder<int, String>({1: '1', 2: '2'});
-      final mapBuilderB = new BuiltMap<int, String>({1: '1', 2: '2'}).toBuilder();
-      expect(mapBuilderA.isEmpty, !mapBuilderA.isNotEmpty);
-      expect(mapBuilderB.isEmpty, !mapBuilderB.isNotEmpty);
+    test('has a method like Map.isEmpty', () {
+      expect(new MapBuilder<int, String>({1: '1', 2: '2'}).isEmpty, false);
+      expect(new BuiltMap<int, String>({1: '1', 2: '2'}).toBuilder().isEmpty, false);
+             
+      expect(new MapBuilder<int, String>().isEmpty, true);
+      expect(new BuiltMap<int, String>().toBuilder().isEmpty, true);
+    });
+             
+    test('has a method like Map.isNotEmpty', () {
+      expect(new MapBuilder<int, String>({1: '1', 2: '2'}).isNotEmpty, true);
+      expect(new BuiltMap<int, String>({1: '1', 2: '2'}).toBuilder().isNotEmpty, true);
+             
+      expect(new MapBuilder<int, String>().isNotEmpty, false);
+      expect(new BuiltMap<int, String>().toBuilder().isNotEmpty, false);
     });
 
     test('has a method like Map.putIfAbsent that returns nothing', () {

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -130,6 +130,21 @@ void main() {
 
     // Set.
 
+    test('has a method like Set.length', () {
+      expect(new SetBuilder<int>([1, 2]).length, 2);
+      expect(new BuiltSet<int>([1, 2]).toBuilder().length, 2);
+      
+      expect(new SetBuilder<int>([]).length, 0);
+      expect(new BuiltSet<int>([]).toBuilder().length, 0);
+    });
+
+    test('has methods like Set.isEmpty and Set.isNotEmpty', () {
+      final setBuilderA = new SetBuilder<int>([1, 2]);
+      final setBuilderB = new BuiltSet<int>([1, 2]).toBuilder();
+      expect(setBuilderA.isEmpty, !setBuilderA.isNotEmpty);
+      expect(setBuilderB.isEmpty, !setBuilderB.isNotEmpty);
+    });
+
     test('has a method like Set.add', () {
       expect((new SetBuilder<int>()..add(1)).build(), [1]);
       expect((new BuiltSet<int>().toBuilder()..add(1)).build(), [1]);

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -138,11 +138,20 @@ void main() {
       expect(new BuiltSet<int>([]).toBuilder().length, 0);
     });
 
-    test('has methods like Set.isEmpty and Set.isNotEmpty', () {
-      final setBuilderA = new SetBuilder<int>([1, 2]);
-      final setBuilderB = new BuiltSet<int>([1, 2]).toBuilder();
-      expect(setBuilderA.isEmpty, !setBuilderA.isNotEmpty);
-      expect(setBuilderB.isEmpty, !setBuilderB.isNotEmpty);
+    test('has a method like Set.isEmpty', () {
+      expect(new SetBuilder<int>([1, 2]).isEmpty, false);
+      expect(new BuiltSet<int>([1, 2]).toBuilder().isEmpty, false);
+             
+      expect(new SetBuilder<int>().isEmpty, true);
+      expect(new BuiltSet<int>().toBuilder().isEmpty, true);
+    });
+
+    test('has a method like Set.isNotEmpty', () {
+      expect(new SetBuilder<int>([1, 2]).isNotEmpty, true);
+      expect(new BuiltSet<int>([1, 2]).toBuilder().isNotEmpty, true);
+             
+      expect(new SetBuilder<int>().isNotEmpty, false);
+      expect(new BuiltSet<int>().toBuilder().isNotEmpty, false);
     });
 
     test('has a method like Set.add', () {


### PR DESCRIPTION
They simply return the value given by respective getter on the underlying collection. In my personal case, they're handy when using the builders in recursive functions -- you don't have to hold onto an index value. 

I really only needed them for ListBuilder, but I went ahead and added them to the Set and Map builders for the sake of consistency between them. I left the multi-map builders alone because I'm not familiar with them and I wasn't sure what value for length they should return. If a maintainer wants to offer direction in that regard, I can go back and add them. 

I also wrote unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/154)
<!-- Reviewable:end -->
