### PR TITLE
Add `from` and `of` constructors to `BuiltList`, `BuiltMap` and `BuiltSet`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@
   - Add `ListBuilder` setters and getters: `first`, `last`.
   - Add `BuiltMap` methods: `entries`, `map`.
   - Add `MapBuilder` methods: `addEntries`, `updateValue`, `updateAllValues`.
-  - Implement Dart 2 methods in internal collections used by `toList`, `toMap` and `toSet`.
+  - Implement Dart 2 methods in internal collections used by `toList`, `toMap`
+    and `toSet`.
+- Add `from` and `of` constructors to `BuiltList`, `BuiltMap` and `BuiltSet`.
+  The `from` constructors, like the current constructors, take collections
+  of any type and check each element. The `of` constructors, like the SDK `of`
+  constructors, take a collection of the correct type. This means they can be
+  used for type inference, allowing you to omit the explicit type.
 
 ## 3.2.0
 

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -20,7 +20,7 @@ class OverriddenHashcodeBuiltList<T> extends _BuiltList<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
-      : super.copyAndCheck(iterable);
+      : super.copyAndCheckTypes(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -23,14 +23,39 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   ///
   /// Wrong: `new BuiltList([1, 2, 3])`.
   ///
-  /// Right: `new BuiltList<int>([1, 2, 3])`,
+  /// Right: `new BuiltList<int>([1, 2, 3])`.
   ///
   /// Rejects nulls. Rejects elements of the wrong type.
-  factory BuiltList([Iterable iterable = const []]) {
+  factory BuiltList([Iterable iterable = const []]) =>
+      new BuiltList<E>.from(iterable);
+
+  /// Instantiates with elements from an [Iterable].
+  ///
+  /// Must be called with a generic type parameter.
+  ///
+  /// Wrong: `new BuiltList.from([1, 2, 3])`.
+  ///
+  /// Right: `new BuiltList<int>.from([1, 2, 3])`.
+  ///
+  /// Rejects nulls. Rejects elements of the wrong type.
+  factory BuiltList.from(Iterable iterable) {
     if (iterable is _BuiltList && iterable.hasExactElementType(E)) {
       return iterable as BuiltList<E>;
     } else {
-      return new _BuiltList<E>.copyAndCheck(iterable);
+      return new _BuiltList<E>.copyAndCheckTypes(iterable);
+    }
+  }
+
+  /// Instantiates with elements from an [Iterable<E>].
+  ///
+  /// `E` must not be `dynamic`.
+  ///
+  /// Rejects nulls. Rejects elements of the wrong type.
+  factory BuiltList.of(Iterable<E> iterable) {
+    if (iterable is _BuiltList<E> && iterable.hasExactElementType(E)) {
+      return iterable;
+    } else {
+      return new _BuiltList<E>.copyAndCheckForNull(iterable);
     }
   }
 
@@ -246,11 +271,20 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 class _BuiltList<E> extends BuiltList<E> {
   _BuiltList.withSafeList(List<E> list) : super._(list);
 
-  _BuiltList.copyAndCheck([Iterable iterable = const []])
+  _BuiltList.copyAndCheckTypes([Iterable iterable = const []])
       : super._(new List<E>.from(iterable, growable: false)) {
     for (final element in _list) {
       if (element is! E) {
         throw new ArgumentError('iterable contained invalid element: $element');
+      }
+    }
+  }
+
+  _BuiltList.copyAndCheckForNull(Iterable<E> iterable)
+      : super._(new List<E>.from(iterable, growable: false)) {
+    for (final element in _list) {
+      if (identical(element, null)) {
+        throw new ArgumentError('iterable contained invalid element: null');
       }
     }
   }

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -16,7 +16,7 @@ class OverriddenHashcodeBuiltMap<K, V> extends _BuiltMap<K, V> {
   final int _overrridenHashCode;
 
   OverriddenHashcodeBuiltMap(map, this._overrridenHashCode)
-      : super.copyAndCheck(map.keys, (k) => map[k]);
+      : super.copyAndCheckTypes(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -19,7 +19,7 @@ class OverriddenHashcodeBuiltSet<T> extends _BuiltSet<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
-      : super.copyAndCheck(iterable);
+      : super.copyAndCheckTypes(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -26,14 +26,39 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   ///
   /// Wrong: `new BuiltSet([1, 2, 3])`.
   ///
-  /// Right: `new BuiltSet<int>([1, 2, 3])`,
+  /// Right: `new BuiltSet<int>([1, 2, 3])`.
   ///
   /// Rejects nulls. Rejects elements of the wrong type.
-  factory BuiltSet([Iterable iterable = const []]) {
+  factory BuiltSet([Iterable iterable = const []]) =>
+      new BuiltSet.from(iterable);
+
+  /// Instantiates with elements from an [Iterable].
+  ///
+  /// Must be called with a generic type parameter.
+  ///
+  /// Wrong: `new BuiltSet([1, 2, 3])`.
+  ///
+  /// Right: `new BuiltSet<int>([1, 2, 3])`.
+  ///
+  /// Rejects nulls. Rejects elements of the wrong type.
+  factory BuiltSet.from(Iterable iterable) {
     if (iterable is _BuiltSet && iterable.hasExactElementType(E)) {
       return iterable as BuiltSet<E>;
     } else {
-      return new _BuiltSet<E>.copyAndCheck(iterable);
+      return new _BuiltSet<E>.copyAndCheckTypes(iterable);
+    }
+  }
+
+  /// Instantiates with elements from an [Iterable<E>].
+  ///
+  /// `E` must not be `dynamic`.
+  ///
+  /// Rejects nulls. Rejects elements of the wrong type.
+  factory BuiltSet.of(Iterable<E> iterable) {
+    if (iterable is _BuiltSet<E> && iterable.hasExactElementType(E)) {
+      return iterable;
+    } else {
+      return new _BuiltSet<E>.copyAndCheckForNull(iterable);
     }
   }
 
@@ -231,12 +256,23 @@ class _BuiltSet<E> extends BuiltSet<E> {
   _BuiltSet.withSafeSet(_SetFactory<E> setFactory, Set<E> set)
       : super._(setFactory, set);
 
-  _BuiltSet.copyAndCheck(Iterable iterable) : super._(null, new Set<E>()) {
+  _BuiltSet.copyAndCheckTypes(Iterable iterable) : super._(null, new Set<E>()) {
     for (final element in iterable) {
       if (element is E) {
         _set.add(element);
       } else {
         throw new ArgumentError('iterable contained invalid element: $element');
+      }
+    }
+  }
+
+  _BuiltSet.copyAndCheckForNull(Iterable iterable)
+      : super._(null, new Set<E>()) {
+    for (final element in iterable) {
+      if (identical(element, null)) {
+        throw new ArgumentError('iterable contained invalid element: null');
+      } else {
+        _set.add(element);
       }
     }
   }

--- a/test/list/built_list_test.dart
+++ b/test/list/built_list_test.dart
@@ -22,12 +22,20 @@ void main() {
       expect(() => new BuiltList(), throwsA(anything));
     });
 
+    test('of constructor throws on attempt to create BuiltList<dynamic>', () {
+      expect(() => new BuiltList.of(<dynamic>[]), throwsA(anything));
+    });
+
     test('allows BuiltList<Object>', () {
       new BuiltList<Object>();
     });
 
     test('can be instantiated from List', () {
       new BuiltList<int>([]);
+    });
+
+    test('of constructor takes inferred type', () {
+      expect(new BuiltList.of([1, 2, 3]), const TypeMatcher<BuiltList<int>>());
     });
 
     test('reports non-emptiness', () {
@@ -85,6 +93,10 @@ void main() {
 
     test('throws on null', () {
       expect(() => new BuiltList<int>([null]), throwsA(anything));
+    });
+
+    test('of constructor throws on null', () {
+      expect(() => new BuiltList<int>.of([null]), throwsA(anything));
     });
 
     test('hashes to same value for same contents', () {

--- a/test/map/built_map_test.dart
+++ b/test/map/built_map_test.dart
@@ -31,12 +31,37 @@ void main() {
       expect(() => new BuiltMap<dynamic, String>(), throwsA(anything));
     });
 
+    test(
+        'of constructor throws on attempt to create BuiltMap<dynamic, dynamic>',
+        () {
+      expect(() => new BuiltMap.of({}), throwsA(anything));
+    });
+
+    test('of constructor throws on attempt to create BuiltMap<String, dynamic>',
+        () {
+      expect(() => new BuiltMap.of(<String, dynamic>{}), throwsA(anything));
+    });
+
+    test('of constructor throws on attempt to create BuiltMap<dynamic, String>',
+        () {
+      expect(() => new BuiltMap.of(<dynamic, String>{}), throwsA(anything));
+    });
+
     test('allows BuiltMap<Object, Object>', () {
       new BuiltMap<Object, Object>();
     });
 
     test('can be instantiated from Map', () {
       new BuiltMap<int, String>({});
+    });
+
+    test('from constructor takes Map', () {
+      new BuiltMap<int, String>.from({});
+    });
+
+    test('of constructor takes inferred type', () {
+      expect(new BuiltMap.of({1: '1'}),
+          const TypeMatcher<BuiltMap<int, String>>());
     });
 
     test('reports non-emptiness', () {
@@ -132,6 +157,15 @@ void main() {
 
     test('throws on null values', () {
       expect(() => new BuiltMap<int, String>({1: null}), throwsA(anything));
+    });
+
+    test('of constructor throws on null keys', () {
+      expect(
+          () => new BuiltMap<int, String>.of({null: '1'}), throwsA(anything));
+    });
+
+    test('of constructor throws on null values', () {
+      expect(() => new BuiltMap<int, String>.of({1: null}), throwsA(anything));
     });
 
     test('hashes to same value for same contents', () {

--- a/test/set/built_set_test.dart
+++ b/test/set/built_set_test.dart
@@ -23,12 +23,20 @@ void main() {
       expect(() => new BuiltSet(), throwsA(anything));
     });
 
+    test('of constructor throws on attempt to create BuiltSet<dynamic>', () {
+      expect(() => new BuiltSet.of(<dynamic>[]), throwsA(anything));
+    });
+
     test('allows BuiltSet<Object>', () {
       new BuiltSet<Object>();
     });
 
     test('can be instantiated from Set', () {
       new BuiltSet<int>([]);
+    });
+
+    test('of constructor takes inferred type', () {
+      expect(new BuiltSet.of([1, 2, 3]), const TypeMatcher<BuiltSet<int>>());
     });
 
     test('reports non-emptiness', () {


### PR DESCRIPTION
This gives a way of using type inference to get the generic type:

`BuiltSet.of([1, 2, 3])`

which I hope will make people happy.

I didn't want to change the default constructor in this release; instead I added e.g. `BuiltList.from` alongside `BuiltList.of`. If we later want to change the default constructor from its current meaning of `from` to `of`, we can look at doing that. (It'll be painful...)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/160)
<!-- Reviewable:end -->
