### PR TITLE
Stop checking types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.1.1 (unreleased)
+
+- Stop doing explicit type checks on elements; in Dart 2 these are implied.
+
 ## 4.1.0
 
 - Add return val to `SetBuilder.add()` to match `Set.add()`.

--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -20,12 +20,15 @@ class BuiltCollectionBenchmark {
       var function = entry.value;
 
       Iterable<int> list = List<int>.generate(1000, (x) => x);
-      Iterable<int> lazyIterable = list.map(_shortDelay);
+      Iterable<int> fastLazyIterable = list.map((x) => x + 1);
+      Iterable<int> slowLazyIterable = list.map(_shortDelay);
       var builderFactory = () => ListBuilder<int>()..addAll(list);
 
       _benchmark('ListBuilder.$name,list', function, builderFactory, list);
+      _benchmark('ListBuilder.$name,fast lazy iterable', function,
+          builderFactory, fastLazyIterable);
       _benchmark('ListBuilder.$name,slow lazy iterable', function,
-          builderFactory, lazyIterable);
+          builderFactory, slowLazyIterable);
     }
   }
 }

--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -268,11 +268,9 @@ class ListBuilder<E> {
     }
   }
 
-  void _checkElements(Iterable elements) {
+  void _checkElements(Iterable<E> elements) {
     for (var element in elements) {
-      if (element is! E) {
-        throw new ArgumentError('invalid element: $element');
-      }
+      _checkElement(element);
     }
   }
 }

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -227,11 +227,9 @@ class MapBuilder<K, V> {
     }
   }
 
-  void _checkKeys(Iterable keys) {
+  void _checkKeys(Iterable<K> keys) {
     for (var key in keys) {
-      if (key is! K) {
-        throw new ArgumentError('invalid key: $key');
-      }
+      _checkKey(key);
     }
   }
 
@@ -241,11 +239,9 @@ class MapBuilder<K, V> {
     }
   }
 
-  void _checkValues(Iterable values) {
+  void _checkValues(Iterable<V> values) {
     for (var value in values) {
-      if (value is! V) {
-        throw new ArgumentError('invalid value: $value');
-      }
+      _checkValue(value);
     }
   }
 }

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -238,11 +238,9 @@ class SetBuilder<E> {
     }
   }
 
-  void _checkElements(Iterable elements) {
+  void _checkElements(Iterable<E> elements) {
     for (var element in elements) {
-      if (element is! E) {
-        throw new ArgumentError('invalid element: $element');
-      }
+      _checkElement(element);
     }
   }
 }


### PR DESCRIPTION
This significantly improves performance when compiled with dart2js and max optimizations `-O4`.

Benchmarks before (higher is better):

Benchmark | data | run 1 | run 2 | run 3
-- | -- | -- | -- | --
ListBuilder.addAll | list | 20 | 20 | 17
ListBuilder.addAll | slow lazy iterable | 14 | 14 | 14
ListBuilder.insertAll | list | 18 | 17 | 17
ListBuilder.insertAll | slow lazy iterable | 14 | 14 | 15
ListBuilder.setAll | list | 21 | 20 | 21
ListBuilder.setAll | slow lazy iterable | 16 | 14 | 15
ListBuilder.setRange | list | 20 | 20 | 19
ListBuilder.setRange | slow lazy iterable | 16 | 16 | 13
ListBuilder.replaceRange | list | 19 | 21 | 20
ListBuilder.replaceRange | slow lazy iterable | 14 | 14 | 15

Benchmarks after (higher is better):

Benchmark | data | run 1 | run 2 | run 3
-- | -- | -- | -- | --
ListBuilder.addAll | list | 570 | 653 | 674
ListBuilder.addAll | slow lazy iterable | 58 | 57 | 55
ListBuilder.insertAll | list | 138 | 129 | 124
ListBuilder.insertAll | slow lazy iterable | 39 | 46 | 45
ListBuilder.setAll | list | 1370 | 1412 | 1410
ListBuilder.setAll | slow lazy iterable | 64 | 62 | 62
ListBuilder.setRange | list | 2181 | 2125 | 2058
ListBuilder.setRange | slow lazy iterable | 64 | 57 | 59
ListBuilder.replaceRange | list | 2674 | 2688 | 2706
ListBuilder.replaceRange | slow lazy iterable | 65 | 63 | 62
  |   |   |   |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/176)
<!-- Reviewable:end -->
