### PR TITLE
Iterate over `Iterable`s only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.1.1 (unreleased)
+## 4.2.0 (unreleased)
 
+- Add benchmark for VM and dart2js.
 - Stop doing explicit type checks on elements; in Dart 2 these are implied.
+- Modify methods on `ListBuilder` and `SetBuilder` that take `Iterable`
+  elements so they only iterate over the iterable once. Improves performance
+  when the iterable are slow/lazy.
 
 ## 4.1.0
 

--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -10,8 +10,14 @@ class BuiltCollectionBenchmark {
     'replaceRange': (b, iterable) => b.replaceRange(0, 1000, iterable),
   };
 
+  final Map<String, void Function(SetBuilder<int>, Iterable<int>)>
+  setBuilderFunctions = {
+    'addAll': (b, iterable) => b.addAll(iterable),
+  };
+
   Future<void> run() async {
     await benchmarkListBuilder();
+    await benchmarkSetBuilder();
   }
 
   Future<void> benchmarkListBuilder() async {
@@ -28,6 +34,24 @@ class BuiltCollectionBenchmark {
       _benchmark('ListBuilder.$name,fast lazy iterable', function,
           builderFactory, fastLazyIterable);
       _benchmark('ListBuilder.$name,slow lazy iterable', function,
+          builderFactory, slowLazyIterable);
+    }
+  }
+
+  Future<void> benchmarkSetBuilder() async {
+    for (var entry in setBuilderFunctions.entries) {
+      var name = entry.key;
+      var function = entry.value;
+
+      Iterable<int> list = List<int>.generate(1000, (x) => x);
+      Iterable<int> fastLazyIterable = list.map((x) => x + 1);
+      Iterable<int> slowLazyIterable = list.map(_shortDelay);
+      var builderFactory = () => SetBuilder<int>();
+
+      _benchmark('SetBuilder.$name,list', function, builderFactory, list);
+      _benchmark('SetBuilder.$name,fast lazy iterable', function,
+          builderFactory, fastLazyIterable);
+      _benchmark('SetBuilder.$name,slow lazy iterable', function,
           builderFactory, slowLazyIterable);
     }
   }

--- a/lib/src/internal/iterables.dart
+++ b/lib/src/internal/iterables.dart
@@ -1,0 +1,15 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:built_collection/src/iterable.dart' show BuiltIterable;
+
+/// Evaluates a lazy iterable.
+///
+/// A whitelist of known non-lazy types is returned directly instead.
+Iterable<E> evaluateIterable<E>(Iterable<E> iterable) {
+  if (iterable is! List && iterable is! BuiltIterable && iterable is! Set) {
+    iterable = iterable.toList();
+  }
+  return iterable;
+}

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -11,6 +11,7 @@ import 'package:built_collection/src/set.dart' show BuiltSet;
 import 'package:quiver/core.dart' show hashObjects;
 
 import 'internal/copy_on_write_list.dart';
+import 'internal/iterables.dart';
 
 part 'list/built_list.dart';
 part 'list/list_builder.dart';

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -10,6 +10,7 @@ import 'package:collection/collection.dart' show UnmodifiableSetView;
 import 'package:quiver/core.dart' show hashObjects;
 
 import 'internal/copy_on_write_set.dart';
+import 'internal/iterables.dart';
 
 part 'set/built_set.dart';
 part 'set/set_builder.dart';

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -115,6 +115,7 @@ class SetBuilder<E> {
 
   /// As [Set.addAll].
   void addAll(Iterable<E> iterable) {
+    iterable = evaluateIterable(iterable);
     _checkElements(iterable);
     _safeSet.addAll(iterable);
   }

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -417,6 +417,44 @@ void main() {
               .build(),
           [2]);
     });
+
+    group('iterates at most once in', () {
+      Iterable<int> onceIterable;
+      setUp(() {
+        var count = 0;
+        onceIterable = [1].map((x) {
+          ++count;
+          if (count > 1) throw StateError('Iterated twice.');
+          return x;
+        });
+      });
+
+      test('addAll', () {
+        new ListBuilder<int>().addAll(onceIterable);
+      });
+
+      test('insertAll', () {
+        new ListBuilder<int>().insertAll(0, onceIterable);
+      });
+
+      test('setAll', () {
+        new ListBuilder<int>()
+          ..addAll([0])
+          ..setAll(0, onceIterable);
+      });
+
+      test('setRange', () {
+        new ListBuilder<int>()
+          ..addAll([0])
+          ..setRange(0, 1, onceIterable);
+      });
+
+      test('replaceRange', () {
+        new ListBuilder<int>()
+          ..addAll([0])
+          ..replaceRange(0, 1, onceIterable);
+      });
+    });
   });
 }
 

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -259,5 +259,21 @@ void main() {
               .build(),
           [2]);
     });
+
+    group('iterates at most once in', () {
+      Iterable<int> onceIterable;
+      setUp(() {
+        var count = 0;
+        onceIterable = [1].map((x) {
+          ++count;
+          if (count > 1) throw StateError('Iterated twice.');
+          return x;
+        });
+      });
+
+      test('addAll', () {
+        new SetBuilder<int>().addAll(onceIterable);
+      });
+    });
   });
 }


### PR DESCRIPTION
Modify methods on `ListBuilder` and `SetBuilder` that take `Iterable` elements so they only iterate over the iterable once. Improves performance when the iterable are slow/lazy.

Add benchmark for `SetBuilder.add`.

Benchmarks before / VM (higher is better):

Benchmark | Data  | run 1  | run 2 | run 3  
-- | -- | -- | -- | --
ListBuilder.addAll | list | 560 | 515 | 564
ListBuilder.addAll | slow lazy iterable | 41 | 45 | 47
ListBuilder.insertAll | list | 30 | 28 | 30
ListBuilder.insertAll | slow lazy iterable | 18 | 16 | 17
ListBuilder.setAll | list | 2802 | 2915 | 2999
ListBuilder.setAll | slow lazy iterable | 60 | 59 | 57
ListBuilder.setRange | list | 2692 | 2617 | 2859
ListBuilder.setRange | slow lazy iterable | 58 | 59 | 58
ListBuilder.replaceRange | list | 2475 | 2454 | 2429
ListBuilder.replaceRange | slow lazy iterable | 56 | 58 | 58
SetBuilder.addAll | list | 941 | 927 | 940
SetBuilder.addAll | slow lazy iterable | 59 | 60 | 60

Benchmarks after / VM (higher is better):

Benchmark | Data  | run 1  | run 2  |  run 3
-- | -- | -- | -- | --
ListBuilder.addAll | list | 527 | 522 | 508
ListBuilder.addAll | slow lazy iterable | 94 | 95 | 84
ListBuilder.insertAll | list | 30 | 30 | 29
ListBuilder.insertAll | slow lazy iterable | 23 | 23 | 21
ListBuilder.setAll | list | 3702 | 3859 | 3860
ListBuilder.setAll | slow lazy iterable | 118 | 117 | 117
ListBuilder.setRange | list | 3800 | 3653 | 3712
ListBuilder.setRange | slow lazy iterable | 111 | 114 | 117
ListBuilder.replaceRange | list | 3772 | 3890 | 3812
ListBuilder.replaceRange | slow lazy iterable | 118 | 117 | 117
SetBuilder.addAll | list | 935 | 955 | 937
SetBuilder.addAll | slow lazy iterable | 110 | 110 | 110

Benchmarks before / dart2js (higher is better):

Benchmark | Data  | run 1  | run 2 | run 3
-- | -- | -- | -- | --
ListBuilder.addAll | list | 570 | 653 | 674
ListBuilder.addAll | slow lazy iterable | 58 | 57 | 55
ListBuilder.insertAll | list | 138 | 129 | 124
ListBuilder.insertAll | slow lazy iterable | 39 | 46 | 45
ListBuilder.setAll | list | 1370 | 1412 | 1410
ListBuilder.setAll | slow lazy iterable | 64 | 62 | 62
ListBuilder.setRange | list | 2181 | 2125 | 2058
ListBuilder.setRange | slow lazy iterable | 64 | 57 | 59
ListBuilder.replaceRange | list | 2674 | 2688 | 2706
ListBuilder.replaceRange | slow lazy iterable | 65 | 63 | 62
SetBuilder.addAll | list | 632 | 669 | 682
SetBuilder.addAll | slow lazy iterable | 48 | 48 | 47

Benchmarks after / dart2js (higher is better):

Benchmark | Data  | run 1  | run 2  |  run 3
-- | -- | -- | -- | --
ListBuilder.addAll | list | 642 | 531 | 510
ListBuilder.addAll | slow lazy iterable | 86 | 89 | 84
ListBuilder.insertAll | list | 126 | 122 | 121
ListBuilder.insertAll | slow lazy iterable | 64 | 58 | 63
ListBuilder.setAll | list | 2374 | 2518 | 2528
ListBuilder.setAll | slow lazy iterable | 125 | 121 | 119
ListBuilder.setRange | list | 5017 | 5119 | 4987
ListBuilder.setRange | slow lazy iterable | 119 | 114 | 123
ListBuilder.replaceRange | list | 5920 | 6068 | 6126
ListBuilder.replaceRange | slow lazy iterable | 128 | 124 | 130
SetBuilder.addAll | list | 668 | 689 | 688
SetBuilder.addAll | slow lazy iterablee | 53 | 56 | 56

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/google/built_collection.dart/177)
<!-- Reviewable:end -->
