### PR TITLE
Fix safety issues for ListBuilder first/last setters

### DIFF
--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -69,7 +69,8 @@ class ListBuilder<E> {
 
   /// As [List.first].
   set first(E value) {
-    _list.first = value;
+    _checkElement(value);
+    _safeList.first = value;
   }
 
   /// As [List.last].
@@ -77,7 +78,8 @@ class ListBuilder<E> {
 
   /// As [List.last].
   set last(E value) {
-    _list.last = value;
+    _checkElement(value);
+    _safeList.last = value;
   }
 
   /// As [List.length].

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -27,6 +27,18 @@ void main() {
       expect(builder.build(), orderedEquals([0]));
     });
 
+    test('throws on null first', () {
+      var builder = new ListBuilder<int>([0]);
+      expect(() => builder.first = null, throwsA(anything));
+      expect(builder.build(), orderedEquals([0]));
+    });
+
+    test('throws on null last', () {
+      var builder = new ListBuilder<int>([0]);
+      expect(() => builder.last = null, throwsA(anything));
+      expect(builder.build(), orderedEquals([0]));
+    });
+
     test('throws on null add', () {
       var builder = new ListBuilder<int>();
       expect(() => builder.add(null), throwsA(anything));
@@ -128,10 +140,95 @@ void main() {
 
     // Lazy copies.
 
-    test('does not mutate BuiltList following reuse of underlying List', () {
+    test('does not mutate BuiltList when modifying ListBuilder assign', () {
       var list = new BuiltList<int>([1, 2]);
       var listBuilder = list.toBuilder();
-      listBuilder.add(3);
+      listBuilder[0] = 3;
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder first', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.first = 3;
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder last', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.last = 3;
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder add', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder[0] = 3;
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder addAll', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.addAll([3, 4]);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder insert', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.insert(0, 3);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder insertAll', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.insertAll(0, [3, 4]);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder setAll', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.setAll(0, [3, 4]);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder setRange', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.setRange(0, 2, [3, 4, 5]);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder fillRange', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.fillRange(0, 2, 3);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder replaceRange',
+        () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.replaceRange(0, 2, [3, 4]);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder map', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.map((x) => 3);
+      expect(list, [1, 2]);
+    });
+
+    test('does not mutate BuiltList when modifying ListBuilder expand', () {
+      var list = new BuiltList<int>([1, 2]);
+      var listBuilder = list.toBuilder();
+      listBuilder.expand((x) => [3, 4]);
       expect(list, [1, 2]);
     });
 

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -164,7 +164,7 @@ void main() {
     test('does not mutate BuiltList when modifying ListBuilder add', () {
       var list = new BuiltList<int>([1, 2]);
       var listBuilder = list.toBuilder();
-      listBuilder[0] = 3;
+      listBuilder.add(3);
       expect(list, [1, 2]);
     });
 


### PR DESCRIPTION
Prevent first= and last= from modifying original BuiltList and from accepting null.