### PR TITLE
Removed incorrect doc example for .of constructor

### DIFF
--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -61,10 +61,6 @@ abstract class BuiltMap<K, V> {
   ///
   /// `K` and `V` must not be `dynamic`.
   ///
-  /// Wrong: `new BuiltMap.of({1: '1', 2: '2', 3: '3'})`.
-  ///
-  /// Right: `new BuiltMap<int, String>.of({1: '1', 2: '2', 3: '3'})`.
-  ///
   /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap.of(Map<K, V> map) {
     return new _BuiltMap<K, V>.copyAndCheckForNull(map.keys, (k) => map[k]);

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -59,7 +59,7 @@ abstract class BuiltMap<K, V> {
 
   /// Instantiates with elements from a [Map<K, V>].
   ///
-  /// `K` and `V` must not be `dynamic`.
+  /// `K` and `V` are inferred from `map`, and must not be `dynamic`.
   ///
   /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap.of(Map<K, V> map) {


### PR DESCRIPTION
Removed incorrect doc example for .of constructor, because dart can infer generic parameters in .of constructor it's actually ok to call it without explicit generic types.