### PR TITLE
safeReplace

### DIFF
--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -53,6 +53,15 @@ class ListBuilder<E> {
     }
   }
 
+  /// Replaces all elements with elements from an [Iterable] of the same element type.
+  void safeReplace(Iterable<E> iterable) {
+    if (iterable is _BuiltList<E>) {
+      _setOwner(iterable);
+    } else {
+      _setSafeList(List.of(iterable));
+    }
+  }
+
   // Based on List.
 
   /// As [List.elementAt].

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -62,6 +62,15 @@ class SetBuilder<E> {
     }
   }
 
+  /// Replaces all elements with elements from an [Iterable] of the same element type.
+  void safeReplace(Iterable<E> iterable) {
+    if (iterable is _BuiltSet<E> && iterable._setFactory == _setFactory) {
+      _withOwner(iterable);
+    } else {
+      _setSafeSet(_createSet()..addAll(iterable));
+    }
+  }
+
   /// Uses `base` as the collection type for all sets created by this builder.
   ///
   ///     // Iterates over elements in ascending order.

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -141,6 +141,10 @@ void main() {
       expect((ListBuilder<int>()..replace([0, 1, 2])).build(), [0, 1, 2]);
     });
 
+    test('has safeReplace method that replaces all data of the same type', () {
+      expect((ListBuilder<int>()..safeReplace([0, 1, 2])).build(), [0, 1, 2]);
+    });
+
     // Lazy copies.
 
     test('does not mutate BuiltList when modifying ListBuilder assign', () {

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -61,6 +61,10 @@ void main() {
       expect((SetBuilder<int>()..replace([0, 1, 2])).build(), [0, 1, 2]);
     });
 
+    test('has safeReplace method that replaces all data of the same type', () {
+      expect((SetBuilder<int>()..safeReplace([0, 1, 2])).build(), [0, 1, 2]);
+    });
+
     test('reuses BuiltSet passed to replace if it has the same base', () {
       var treeSetBase = () => SplayTreeSet<int>();
       var set = BuiltSet<int>.build((b) => b


### PR DESCRIPTION
Added `ListBuilder. safeReplace(Iterable<E>)` and `SetBuilder. safeReplace(Iterable<E>)`. That allows compile-time safety instead of using `replace(Iterable<dynamic>)`