### PR TITLE
Add ignore to prepare for flow analysis change.

### DIFF
--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -122,7 +122,7 @@ abstract class BuiltListMultimap<K, V> {
   /// As [ListMultimap], but results are [BuiltList]s and not mutable.
   BuiltList<V> operator [](Object? key) {
     var result = _map[key];
-    return identical(result, null) ? _emptyList : result!;
+    return identical(result, null) ? _emptyList : result!; // ignore: unnecessary_non_null_assertion
   }
 
   /// As [ListMultimap.containsKey].


### PR DESCRIPTION
I will soon be landing a change to flow analysis that causes calls to
`identical` to be accounted for in type promotion (see
https://github.com/dart-lang/language/issues/1226), so the statement:

    return identical(result, null) ? _emptyList : result!;

will no longer need a `!`.  To avoid a nuisance
unnecessary_non_null_assertion warning when this change happens, we
add an "ignore" comment.  Once flow analysis the change has landed,
I'll make a follow-up change that removes the unnecessary `!`.