### PR TITLE
Remove unnecessary non null assertion.

### DIFF
--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -122,7 +122,7 @@ abstract class BuiltListMultimap<K, V> {
   /// As [ListMultimap], but results are [BuiltList]s and not mutable.
   BuiltList<V> operator [](Object? key) {
     var result = _map[key];
-    return identical(result, null) ? _emptyList : result!; // ignore: unnecessary_non_null_assertion
+    return identical(result, null) ? _emptyList : result;
   }
 
   /// As [ListMultimap.containsKey].


### PR DESCRIPTION
The SDK was updated so the null assert isn't needed--and it causes a warning in the CFE that we can't currently turn off :)