### PR TITLE
Remove null-safety experiment settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: dart
-dart: dev
+dart:
+  - dev
+  - beta
 script:
   - tool/presubmit

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,1 @@
 include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  enable-experiment:
-    - non-nullable

--- a/tool/presubmit
+++ b/tool/presubmit
@@ -5,13 +5,13 @@
 
 set -e
 
-dartfmt -w $(find bin lib test -name \*.dart 2>/dev/null)
-pub get
-pub upgrade
+dart format $(find bin lib test -name \*.dart 2>/dev/null)
+dart pub get
+dart pub upgrade
+# For dart analyze there is no way yet to give a list of files
 dartanalyzer \
-    --enable-experiment=non-nullable \
     --fatal-warnings \
     --fatal-infos \
     $(find bin lib test -name \*.dart 2>/dev/null)
 
-pub run test
+dart test


### PR DESCRIPTION
As with 2.12 this is no longer an experiment this setting should be removed from the `analysis_options.yaml`