### PR TITLE
Remove explicit null and type checks in `BuiltList`/`ListBuilder`.

### DIFF
--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -11,7 +11,6 @@ import 'package:built_collection/src/set.dart' show BuiltSet;
 
 import 'internal/copy_on_write_list.dart';
 import 'internal/hash.dart';
-import 'internal/iterables.dart';
 
 part 'list/built_list.dart';
 part 'list/list_builder.dart';
@@ -21,7 +20,7 @@ class OverriddenHashcodeBuiltList<T> extends _BuiltList<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
-      : super.copyAndCheckTypes(iterable);
+      : super.copy(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -24,8 +24,6 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   /// Wrong: `new BuiltList([1, 2, 3])`.
   ///
   /// Right: `new BuiltList<int>([1, 2, 3])`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltList([Iterable iterable = const []]) =>
       BuiltList<E>.from(iterable);
 
@@ -36,26 +34,22 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   /// Wrong: `new BuiltList.from([1, 2, 3])`.
   ///
   /// Right: `new BuiltList<int>.from([1, 2, 3])`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltList.from(Iterable iterable) {
     if (iterable is _BuiltList && iterable.hasExactElementType(E)) {
       return iterable as BuiltList<E>;
     } else {
-      return _BuiltList<E>.copyAndCheckTypes(iterable);
+      return _BuiltList<E>.copy(iterable);
     }
   }
 
   /// Instantiates with elements from an [Iterable<E>].
   ///
   /// `E` must not be `dynamic`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltList.of(Iterable<E> iterable) {
     if (iterable is _BuiltList<E> && iterable.hasExactElementType(E)) {
       return iterable;
     } else {
-      return _BuiltList<E>.copyAndCheckForNull(iterable);
+      return _BuiltList<E>.copy(iterable);
     }
   }
 
@@ -268,23 +262,8 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 class _BuiltList<E> extends BuiltList<E> {
   _BuiltList.withSafeList(List<E> list) : super._(list);
 
-  _BuiltList.copyAndCheckTypes([Iterable iterable = const []])
-      : super._(List<E>.from(iterable, growable: false)) {
-    _checkForNull();
-  }
-
-  _BuiltList.copyAndCheckForNull(Iterable<E> iterable)
-      : super._(List<E>.from(iterable, growable: false)) {
-    _checkForNull();
-  }
-
-  void _checkForNull() {
-    for (var element in _list) {
-      if (identical(element, null)) {
-        throw ArgumentError('iterable contained invalid element: null');
-      }
-    }
-  }
+  _BuiltList.copy([Iterable iterable = const []])
+      : super._(List<E>.from(iterable, growable: false));
 
   bool hasExactElementType(Type type) => E == type;
 }
@@ -294,7 +273,7 @@ extension BuiltListExtension<T> on List<T> {
   /// Converts to a [BuiltList].
   BuiltList<T> build() {
     // We know a `List` is not a `BuiltList`, so we have to copy.
-    return _BuiltList<T>.copyAndCheckForNull(this);
+    return _BuiltList<T>.copy(this);
   }
 }
 

--- a/test/list/built_list_test.dart
+++ b/test/list/built_list_test.dart
@@ -94,6 +94,10 @@ void main() {
       expect(() => BuiltList<int>([null]), throwsA(anything));
     });
 
+    test('nullable can store null', () {
+      expect(BuiltList<int?>([null])[0], null);
+    });
+
     test('of constructor throws on null', () {
       expect(() => BuiltList<int>.of([null as int]), throwsA(anything));
     });

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -23,83 +23,163 @@ void main() {
 
     test('throws on null assign', () {
       var builder = ListBuilder<int>([0]);
-      expect(() => builder[0] = null as int, throwsA(anything));
+      expect(() => builder[0] = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
+    });
+
+    test('nullable does not throw on null assign', () {
+      var builder = ListBuilder<int?>([0]);
+      builder[0] = null;
+      expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null first', () {
       var builder = ListBuilder<int>([0]);
-      expect(() => builder.first = null as int, throwsA(anything));
+      expect(() => builder.first = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
+    });
+
+    test('nullable does not throw on null first', () {
+      var builder = ListBuilder<int?>([0]);
+      builder.first = null;
+      expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null last', () {
       var builder = ListBuilder<int>([0]);
-      expect(() => builder.last = null as int, throwsA(anything));
+      expect(() => builder.last = null as dynamic, throwsA(anything));
       expect(builder.build(), orderedEquals([0]));
+    });
+
+    test('nullable does not throw on null last', () {
+      var builder = ListBuilder<int?>([0]);
+      builder.last = null;
+      expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null add', () {
       var builder = ListBuilder<int>();
-      expect(() => builder.add(null as int), throwsA(anything));
+      expect(() => builder.add(null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null add', () {
+      var builder = ListBuilder<int?>();
+      builder.add(null);
+      expect(builder.build(), [null]);
     });
 
     test('throws on null addAll', () {
       var builder = ListBuilder<int>();
-      expect(() => builder.addAll([0, 1, null as int]), throwsA(anything));
+      expect(() => builder.addAll([0, 1, null as dynamic]), throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null addAll', () {
+      var builder = ListBuilder<int?>();
+      builder.addAll([0, 1, null]);
+      expect(builder.build(), [0, 1, null]);
     });
 
     test('throws on null insert', () {
       var builder = ListBuilder<int>();
-      expect(() => builder.insert(0, null as int), throwsA(anything));
+      expect(() => builder.insert(0, null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null insert', () {
+      var builder = ListBuilder<int?>();
+      builder.insert(0, null);
+      expect(builder.build(), [null]);
     });
 
     test('throws on null insertAll', () {
       var builder = ListBuilder<int>();
-      expect(
-          () => builder.insertAll(0, [0, 1, null as int]), throwsA(anything));
+      expect(() => builder.insertAll(0, [0, 1, null as dynamic]),
+          throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null insertAll', () {
+      var builder = ListBuilder<int?>();
+      builder.insertAll(0, [0, 1, null]);
+      expect(builder.build(), [0, 1, null]);
     });
 
     test('throws on null setAll', () {
       var builder = ListBuilder<int>([0, 1, 2]);
-      expect(() => builder.setAll(0, [0, 1, null as int]), throwsA(anything));
+      expect(
+          () => builder.setAll(0, [0, 1, null as dynamic]), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null setAll', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.setAll(0, [0, 1, null]);
+      expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null setRange', () {
       var builder = ListBuilder<int>([0, 1, 2]);
-      expect(
-          () => builder.setRange(0, 2, [0, 1, null as int]), throwsA(anything));
-      expect(builder.build(), orderedEquals([0, 1, 2]));
-    });
-
-    test('throws on null fillRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
-      expect(() => builder.fillRange(0, 2, null as int), throwsA(anything));
-      expect(builder.build(), orderedEquals([0, 1, 2]));
-    });
-
-    test('throws on null replaceRange', () {
-      var builder = ListBuilder<int>([0, 1, 2]);
-      expect(() => builder.replaceRange(0, 2, [0, 1, null as int]),
+      expect(() => builder.setRange(0, 3, [0, 1, null as dynamic]),
           throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
     });
 
+    test('nullable does not throw on null setRange', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.setRange(0, 3, [0, 1, null]);
+      expect(builder.build(), orderedEquals([0, 1, null]));
+    });
+
+    test('throws on null fillRange', () {
+      var builder = ListBuilder<int>([0, 1, 2]);
+      expect(() => builder.fillRange(0, 3, null as dynamic), throwsA(anything));
+      expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null fillRange', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.fillRange(0, 3, null);
+      expect(builder.build(), orderedEquals([null, null, null]));
+    });
+
+    test('throws on null replaceRange', () {
+      var builder = ListBuilder<int>([0, 1, 2]);
+      expect(() => builder.replaceRange(0, 3, [0, 1, null as dynamic]),
+          throwsA(anything));
+      expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null replaceRange', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.replaceRange(0, 3, [0, 1, null]);
+      expect(builder.build(), orderedEquals([0, 1, null]));
+    });
+
     test('throws on null map', () {
       var builder = ListBuilder<int>([0, 1, 2]);
-      expect(() => builder.map((x) => null as int), throwsA(anything));
+      expect(() => builder.map((x) => null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null map', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.map((x) => null);
+      expect(builder.build(), orderedEquals([null, null, null]));
     });
 
     test('throws on null expand', () {
       var builder = ListBuilder<int>([0, 1, 2]);
-      expect(() => builder.expand((x) => [x, null as int]), throwsA(anything));
+      expect(
+          () => builder.expand((x) => [x, null as dynamic]), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null expand', () {
+      var builder = ListBuilder<int?>([0, 1, 2]);
+      builder.expand((x) => [x, null]);
+      expect(builder.build(), orderedEquals([0, null, 1, null, 2, null]));
     });
 
     test('throws on wrong type addAll', () {


### PR DESCRIPTION
Rely on language checks instead. This allows a `BuiltList<T?>` to contain nulls.