### PR TITLE
Remove explicit null and type checks in `BuiltSet`/`SetBuilder`.

### DIFF
--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -10,7 +10,6 @@ import 'package:built_collection/src/list.dart' show BuiltList;
 import 'internal/hash.dart';
 import 'internal/copy_on_write_set.dart';
 import 'internal/unmodifiable_set.dart';
-import 'internal/iterables.dart';
 
 part 'set/built_set.dart';
 part 'set/set_builder.dart';
@@ -20,7 +19,7 @@ class OverriddenHashcodeBuiltSet<T> extends _BuiltSet<T> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
-      : super.copyAndCheckTypes(iterable);
+      : super.copy(iterable);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -27,8 +27,6 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   /// Wrong: `new BuiltSet([1, 2, 3])`.
   ///
   /// Right: `new BuiltSet<int>([1, 2, 3])`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltSet([Iterable iterable = const []]) => BuiltSet.from(iterable);
 
   /// Instantiates with elements from an [Iterable].
@@ -38,26 +36,22 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
   /// Wrong: `new BuiltSet([1, 2, 3])`.
   ///
   /// Right: `new BuiltSet<int>([1, 2, 3])`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltSet.from(Iterable iterable) {
     if (iterable is _BuiltSet && iterable.hasExactElementType(E)) {
       return iterable as BuiltSet<E>;
     } else {
-      return _BuiltSet<E>.copyAndCheckTypes(iterable);
+      return _BuiltSet<E>.copy(iterable);
     }
   }
 
   /// Instantiates with elements from an [Iterable<E>].
   ///
   /// `E` must not be `dynamic`.
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory BuiltSet.of(Iterable<E> iterable) {
     if (iterable is _BuiltSet<E> && iterable.hasExactElementType(E)) {
       return iterable;
     } else {
-      return _BuiltSet<E>.copyAndCheckForNull(iterable);
+      return _BuiltSet<E>.copy(iterable);
     }
   }
 
@@ -256,23 +250,9 @@ class _BuiltSet<E> extends BuiltSet<E> {
   _BuiltSet.withSafeSet(_SetFactory<E>? setFactory, Set<E> set)
       : super._(setFactory, set);
 
-  _BuiltSet.copyAndCheckTypes(Iterable iterable) : super._(null, <E>{}) {
+  _BuiltSet.copy(Iterable iterable) : super._(null, <E>{}) {
     for (var element in iterable) {
-      if (element is E) {
-        _set.add(element);
-      } else {
-        throw ArgumentError('iterable contained invalid element: $element');
-      }
-    }
-  }
-
-  _BuiltSet.copyAndCheckForNull(Iterable iterable) : super._(null, <E>{}) {
-    for (var element in iterable) {
-      if (identical(element, null)) {
-        throw ArgumentError('iterable contained invalid element: null');
-      } else {
-        _set.add(element);
-      }
+      _set.add(element);
     }
   }
 
@@ -284,7 +264,7 @@ extension BuiltSetExtension<T> on Set<T> {
   /// Converts to a [BuiltSet].
   BuiltSet<T> build() {
     // We know a `Set` is not a `BuiltSet`, so we have to copy.
-    return _BuiltSet<T>.copyAndCheckForNull(this);
+    return _BuiltSet<T>.copy(this);
   }
 }
 

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -24,8 +24,6 @@ class SetBuilder<E> {
   /// Wrong: `new SetBuilder([1, 2, 3])`.
   ///
   /// Right: `new SetBuilder<int>([1, 2, 3])`,
-  ///
-  /// Rejects nulls. Rejects elements of the wrong type.
   factory SetBuilder([Iterable iterable = const []]) {
     return SetBuilder<E>._uninitialized()..replace(iterable);
   }
@@ -104,14 +102,11 @@ class SetBuilder<E> {
 
   /// As [Set.add].
   bool add(E value) {
-    _checkElement(value);
     return _safeSet.add(value);
   }
 
   /// As [Set.addAll].
   void addAll(Iterable<E> iterable) {
-    iterable = evaluateIterable(iterable);
-    _checkElements(iterable);
     _safeSet.addAll(iterable);
   }
 
@@ -149,9 +144,7 @@ class SetBuilder<E> {
 
   /// As [Iterable.map], but updates the builder in place. Returns nothing.
   void map(E Function(E) f) {
-    var result = _createSet()..addAll(_set.map(f));
-    _checkElements(result);
-    _setSafeSet(result);
+    _setSafeSet(_createSet()..addAll(_set.map(f)));
   }
 
   /// As [Iterable.where], but updates the builder in place. Returns nothing.
@@ -161,9 +154,7 @@ class SetBuilder<E> {
 
   /// As [Iterable.expand], but updates the builder in place. Returns nothing.
   void expand(Iterable<E> Function(E) f) {
-    var result = _createSet()..addAll(_set.expand(f));
-    _checkElements(result);
-    _setSafeSet(result);
+    _setSafeSet(_createSet()..addAll(_set.expand(f)));
   }
 
   /// As [Iterable.take], but updates the builder in place. Returns nothing.
@@ -225,18 +216,6 @@ class SetBuilder<E> {
     if (E == dynamic) {
       throw UnsupportedError('explicit element type required, '
           'for example "new SetBuilder<int>"');
-    }
-  }
-
-  void _checkElement(E element) {
-    if (identical(element, null)) {
-      throw ArgumentError('null element');
-    }
-  }
-
-  void _checkElements(Iterable<E> elements) {
-    for (var element in elements) {
-      _checkElement(element);
     }
   }
 }

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -22,32 +22,56 @@ void main() {
 
     test('throws on null add', () {
       var builder = SetBuilder<int>();
-      expect(() => builder.add(null as int), throwsA(anything));
+      expect(() => builder.add(null as dynamic), throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null add', () {
+      var builder = SetBuilder<int?>();
+      builder.add(null);
+      expect(builder.build(), {null});
     });
 
     test('throws on null addAll', () {
       var builder = SetBuilder<int>();
-      expect(() => builder.addAll([0, 1, null as int]), throwsA(anything));
+      expect(() => builder.addAll([0, 1, null as dynamic]), throwsA(anything));
       expect(builder.build(), isEmpty);
+    });
+
+    test('nullable does not throw on null addAll', () {
+      var builder = SetBuilder<int?>();
+      builder.addAll([0, 1, null]);
+      expect(builder.build(), orderedEquals([0, 1, null]));
     });
 
     test('throws on null map', () {
       var builder = SetBuilder<int>([0, 1, 2]);
-      expect(() => builder.map((x) => null as int), throwsA(anything));
+      expect(() => builder.map((x) => null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null map', () {
+      var builder = SetBuilder<int?>([0, 1, 2]);
+      builder.map((x) => null);
+      expect(builder.build(), orderedEquals([null]));
     });
 
     test('throws on null expand', () {
       var builder = SetBuilder<int>([0, 1, 2]);
-      expect(() => builder.expand((x) => [x, null as int]), throwsA(anything));
+      expect(
+          () => builder.expand((x) => [x, null as dynamic]), throwsA(anything));
       expect(builder.build(), orderedEquals([0, 1, 2]));
+    });
+
+    test('nullable does not throw on null expand', () {
+      var builder = SetBuilder<int?>([0, 1, 2]);
+      builder.expand((x) => [x, null]);
+      expect(builder.build(), orderedEquals([0, null, 1, 2]));
     });
 
     test('throws on null withBase', () {
       var builder = SetBuilder<int>([2, 0, 1]);
-      expect(() => builder.withBase(null as Set<int> Function()),
-          throwsA(anything));
+      expect(() => builder.withBase(null as dynamic), throwsA(anything));
       expect(builder.build(), orderedEquals([2, 0, 1]));
     });
 


### PR DESCRIPTION
Rely on language checks instead. This allows a `BuiltSet<T?>` to contain nulls.