### PR TITLE
Remove explicit null and type checks in `BuiltMap`/`MapBuilder`.

### DIFF
--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -31,8 +31,6 @@ abstract class BuiltMap<K, V> {
   /// Wrong: `new BuiltMap({1: '1', 2: '2', 3: '3'})`.
   ///
   /// Right: `new BuiltMap<int, String>({1: '1', 2: '2', 3: '3'})`.
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap([map = const {}]) {
     if (map is _BuiltMap && map.hasExactKeyAndValueTypes(K, V)) {
       return map as BuiltMap<K, V>;
@@ -50,8 +48,6 @@ abstract class BuiltMap<K, V> {
   /// Wrong: `new BuiltMap.from({1: '1', 2: '2', 3: '3'})`.
   ///
   /// Right: `new BuiltMap<int, String>.from({1: '1', 2: '2', 3: '3'})`.
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap.from(Map map) {
     return _BuiltMap<K, V>.copyAndCheckTypes(map.keys, (k) => map[k]);
   }
@@ -59,10 +55,8 @@ abstract class BuiltMap<K, V> {
   /// Instantiates with elements from a [Map<K, V>].
   ///
   /// `K` and `V` are inferred from `map`, and must not be `dynamic`.
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltMap.of(Map<K, V> map) {
-    return _BuiltMap<K, V>.copyAndCheckForNull(map.keys, (k) => map[k]!);
+    return _BuiltMap<K, V>.copy(map.keys, (k) => map[k] as V);
   }
 
   /// Creates a [MapBuilder], applies updates to it, and builds.
@@ -207,16 +201,10 @@ class _BuiltMap<K, V> extends BuiltMap<K, V> {
     }
   }
 
-  _BuiltMap.copyAndCheckForNull(Iterable<K> keys, V Function(K) lookup)
+  _BuiltMap.copy(Iterable<K> keys, V Function(K) lookup)
       : super._(null, <K, V>{}) {
     for (var key in keys) {
-      if (identical(key, null)) {
-        throw ArgumentError('map contained invalid key: null');
-      }
       var value = lookup(key);
-      if (value == null) {
-        throw ArgumentError('map contained invalid value: null');
-      }
       _map[key] = value;
     }
   }

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -113,8 +113,6 @@ class MapBuilder<K, V> {
 
   /// As [Map].
   void operator []=(K key, V value) {
-    _checkKey(key);
-    _checkValue(value);
     _safeMap[key] = value;
   }
 
@@ -129,18 +127,11 @@ class MapBuilder<K, V> {
 
   /// As [Map.putIfAbsent].
   V putIfAbsent(K key, V Function() ifAbsent) {
-    _checkKey(key);
-    return _safeMap.putIfAbsent(key, () {
-      var value = ifAbsent();
-      _checkValue(value);
-      return value;
-    });
+    return _safeMap.putIfAbsent(key, ifAbsent);
   }
 
   /// As [Map.addAll].
   void addAll(Map<K, V> other) {
-    _checkKeys(other.keys);
-    _checkValues(other.values);
     _safeMap.addAll(other);
   }
 
@@ -212,30 +203,6 @@ class MapBuilder<K, V> {
     if (V == dynamic) {
       throw UnsupportedError('explicit value type required, '
           'for example "new MapBuilder<int, int>"');
-    }
-  }
-
-  void _checkKey(K key) {
-    if (identical(key, null)) {
-      throw ArgumentError('null key');
-    }
-  }
-
-  void _checkKeys(Iterable<K> keys) {
-    for (var key in keys) {
-      _checkKey(key);
-    }
-  }
-
-  void _checkValue(V value) {
-    if (identical(value, null)) {
-      throw ArgumentError('null value');
-    }
-  }
-
-  void _checkValues(Iterable<V> values) {
-    for (var value in values) {
-      _checkValue(value);
     }
   }
 }

--- a/test/map/built_map_test.dart
+++ b/test/map/built_map_test.dart
@@ -150,18 +150,34 @@ void main() {
       expect(() => BuiltMap<int, String>({null: '1'}), throwsA(anything));
     });
 
+    test('nullable does not throw on null keys', () {
+      expect(BuiltMap<int?, String>({null: '1'})[null], '1');
+    });
+
     test('throws on null values', () {
       expect(() => BuiltMap<int, String>({1: null}), throwsA(anything));
     });
 
+    test('nullable does not throw on null values', () {
+      expect(BuiltMap<int, String?>({1: null})[1], null);
+    });
+
     test('of constructor throws on null keys', () {
-      expect(() => BuiltMap<int, String>.of({null as int: '1'}),
+      expect(() => BuiltMap<int, String>.of({null as dynamic: '1'}),
           throwsA(anything));
     });
 
+    test('nullable of constructor does not throw on null keys', () {
+      expect(BuiltMap<int?, String>.of({null as dynamic: '1'})[null], '1');
+    });
+
     test('of constructor throws on null values', () {
-      expect(() => BuiltMap<int, String>.of({1: null as String}),
+      expect(() => BuiltMap<int, String>.of({1: null as dynamic}),
           throwsA(anything));
+    });
+
+    test('nullable of constructor does not throw on null values', () {
+      expect(BuiltMap<int, String?>.of({1: null as dynamic})[1], null);
     });
 
     test('hashes to same value for same contents', () {

--- a/test/map/map_builder_test.dart
+++ b/test/map/map_builder_test.dart
@@ -29,41 +29,77 @@ void main() {
     });
 
     test('throws on null key put', () {
-      expect(() => MapBuilder<int, String>()[null as int] = '0',
+      expect(() => MapBuilder<int, String>()[null as dynamic] = '0',
           throwsA(anything));
     });
 
+    test('nullable does not throw on null key put', () {
+      var builder = MapBuilder<int?, String>();
+      builder[null] = '0';
+      expect(builder[null], '0');
+    });
+
     test('throws on null value put', () {
-      expect(() => MapBuilder<int, String>()[0] = null as String,
+      expect(() => MapBuilder<int, String>()[0] = null as dynamic,
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null value put', () {
+      var builder = MapBuilder<int, String?>();
+      builder[0] = null;
+      expect(builder[0], null);
     });
 
     test('throws on null key putIfAbsent', () {
       expect(
-          () => MapBuilder<int, String>().putIfAbsent(null as int, () => '0'),
+          () =>
+              MapBuilder<int, String>().putIfAbsent(null as dynamic, () => '0'),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null key putIfAbsent', () {
+      var builder = MapBuilder<int?, String>();
+      builder.putIfAbsent(null, () => '0');
+      expect(builder[null], '0');
     });
 
     test('throws on null value putIfAbsent', () {
       expect(
-          () => MapBuilder<int, String>().putIfAbsent(0, () => null as String),
+          () => MapBuilder<int, String>().putIfAbsent(0, () => null as dynamic),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null value putIfAbsent', () {
+      var builder = MapBuilder<int, String?>();
+      builder.putIfAbsent(0, () => null);
+      expect(builder[0], null);
     });
 
     test('throws on null key addAll', () {
-      expect(() => MapBuilder<int, String>().addAll({null as int: '0'}),
+      expect(() => MapBuilder<int, String>().addAll({null as dynamic: '0'}),
           throwsA(anything));
     });
 
+    test('nullable does not throw on null key addAll', () {
+      var builder = MapBuilder<int?, String>();
+      builder.addAll({null: '0'});
+      expect(builder[null], '0');
+    });
+
     test('throws on null value addAll', () {
-      expect(() => MapBuilder<int, String>().addAll({0: null as String}),
+      expect(() => MapBuilder<int, String>().addAll({0: null as dynamic}),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null value addAll', () {
+      var builder = MapBuilder<int, String?>();
+      builder.addAll({0: null});
+      expect(builder[0], null);
     });
 
     test('throws on null withBase', () {
       var builder = MapBuilder<int, String>({2: '2', 0: '0', 1: '1'});
-      expect(() => builder.withBase(null as Map<int, String> Function()),
-          throwsA(anything));
+      expect(() => builder.withBase(null as dynamic), throwsA(anything));
       expect(builder.build().keys, orderedEquals([2, 0, 1]));
     });
 


### PR DESCRIPTION
Rely on language checks instead. This allows a `BuiltMap<T?>` to contain nulls.