### PR TITLE
Remove explicit null and type checks in `BuiltListMultimap`/`ListMultimapBuilder`.

### DIFF
--- a/lib/src/list_multimap.dart
+++ b/lib/src/list_multimap.dart
@@ -18,7 +18,7 @@ class OverriddenHashcodeBuiltListMultimap<K, V>
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltListMultimap(map, this._overridenHashCode)
-      : super.copyAndCheck(map.keys, (k) => map[k]);
+      : super.copy(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -35,21 +35,16 @@ abstract class BuiltListMultimap<K, V> {
   ///
   /// Right:
   ///   `new BuiltListMultimap<int, String>({1: ['1'], 2: ['2'], 3: ['3']})`,
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory BuiltListMultimap([multimap = const {}]) {
     if (multimap is _BuiltListMultimap &&
         multimap.hasExactKeyAndValueTypes(K, V)) {
       return multimap as BuiltListMultimap<K, V>;
     } else if (multimap is Map) {
-      return _BuiltListMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltListMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     } else if (multimap is BuiltListMultimap) {
-      return _BuiltListMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltListMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     } else {
-      return _BuiltListMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltListMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     }
   }
 
@@ -188,7 +183,7 @@ abstract class BuiltListMultimap<K, V> {
 class _BuiltListMultimap<K, V> extends BuiltListMultimap<K, V> {
   _BuiltListMultimap.withSafeMap(Map<K, BuiltList<V>> map) : super._(map);
 
-  _BuiltListMultimap.copyAndCheck(Iterable keys, Function lookup)
+  _BuiltListMultimap.copy(Iterable keys, Function lookup)
       : super._(<K, BuiltList<V>>{}) {
     for (var key in keys) {
       if (key is K) {

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -31,8 +31,6 @@ class ListMultimapBuilder<K, V> {
   ///
   /// Right:
   ///   `new ListMultimapBuilder<int, String>({1: ['1'], 2: ['2'], 3: ['3']})`,
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory ListMultimapBuilder([multimap = const {}]) {
     return ListMultimapBuilder<K, V>._uninitialized()..replace(multimap);
   }
@@ -113,8 +111,6 @@ class ListMultimapBuilder<K, V> {
   /// As [ListMultimap.add].
   void add(K key, V value) {
     _makeWriteableCopy();
-    _checkKey(key);
-    _checkValue(value);
     _getValuesBuilder(key).add(value);
   }
 
@@ -225,18 +221,6 @@ class ListMultimapBuilder<K, V> {
     if (V == dynamic) {
       throw UnsupportedError('explicit value type required, '
           'for example "new ListMultimapBuilder<int, int>"');
-    }
-  }
-
-  void _checkKey(K key) {
-    if (identical(key, null)) {
-      throw ArgumentError('null key');
-    }
-  }
-
-  void _checkValue(V value) {
-    if (identical(value, null)) {
-      throw ArgumentError('null value');
     }
   }
 }

--- a/test/list_multimap/built_list_multimap_test.dart
+++ b/test/list_multimap/built_list_multimap_test.dart
@@ -153,9 +153,24 @@ void main() {
           throwsA(anything));
     });
 
+    test('nullable does not throw on null keys', () {
+      expect(
+          BuiltListMultimap<int?, String>({
+            null: ['1']
+          }).asMap(),
+          {
+            null: ['1']
+          });
+    });
+
     test('throws on null value iterables', () {
       expect(
           () => BuiltListMultimap<int, String>({1: null}), throwsA(anything));
+    });
+
+    test('nullable also throws on null value iterables', () {
+      expect(
+          () => BuiltListMultimap<int, String?>({1: null}), throwsA(anything));
     });
 
     test('throws on null values', () {
@@ -164,6 +179,16 @@ void main() {
                 1: [null]
               }),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null values', () {
+      expect(
+          BuiltListMultimap<int, String?>({
+            1: [null]
+          }).asMap(),
+          {
+            1: [null]
+          });
     });
 
     test('hashes to same value for same contents', () {

--- a/test/list_multimap/list_multimap_builder_test.dart
+++ b/test/list_multimap/list_multimap_builder_test.dart
@@ -31,13 +31,25 @@ void main() {
     });
 
     test('throws on null key add', () {
-      expect(() => ListMultimapBuilder<int, String>().add(null as int, '0'),
+      expect(() => ListMultimapBuilder<int, String>().add(null as dynamic, '0'),
           throwsA(anything));
     });
 
+    test('nullable does not throw on null key add', () {
+      var builder = ListMultimapBuilder<int?, String>();
+      builder.add(null, '0');
+      expect(builder[null].build(), ['0']);
+    });
+
     test('throws on null value add', () {
-      expect(() => ListMultimapBuilder<int, String>().add(0, null as String),
+      expect(() => ListMultimapBuilder<int, String>().add(0, null as dynamic),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null value add', () {
+      var builder = ListMultimapBuilder<int, String?>();
+      builder.add(0, null);
+      expect(builder[0].build(), [null]);
     });
 
     test('throws on wrong type value addValues', () {


### PR DESCRIPTION

Rely on language checks instead. This allows a `BuiltListMultimap<K?, V?>` to contain nulls.