### PR TITLE
Remove explicit null and type checks in `BuiltSetMultimap`/`SetMultimapBuilder`.

### DIFF
--- a/lib/src/set_multimap.dart
+++ b/lib/src/set_multimap.dart
@@ -17,7 +17,7 @@ class OverriddenHashcodeBuiltSetMultimap<K, V> extends _BuiltSetMultimap<K, V> {
   final int _overridenHashCode;
 
   OverriddenHashcodeBuiltSetMultimap(map, this._overridenHashCode)
-      : super.copyAndCheck(map.keys, (k) => map[k]);
+      : super.copy(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -41,14 +41,11 @@ abstract class BuiltSetMultimap<K, V> {
         multimap.hasExactKeyAndValueTypes(K, V)) {
       return multimap as BuiltSetMultimap<K, V>;
     } else if (multimap is Map) {
-      return _BuiltSetMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltSetMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     } else if (multimap is BuiltSetMultimap) {
-      return _BuiltSetMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltSetMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     } else {
-      return _BuiltSetMultimap<K, V>.copyAndCheck(
-          multimap.keys, (k) => multimap[k]);
+      return _BuiltSetMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
     }
   }
 
@@ -185,7 +182,7 @@ abstract class BuiltSetMultimap<K, V> {
 class _BuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
   _BuiltSetMultimap.withSafeMap(Map<K, BuiltSet<V>> map) : super._(map);
 
-  _BuiltSetMultimap.copyAndCheck(Iterable keys, Function lookup)
+  _BuiltSetMultimap.copy(Iterable keys, Function lookup)
       : super._(<K, BuiltSet<V>>{}) {
     for (var key in keys) {
       if (key is K) {

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -31,8 +31,6 @@ class SetMultimapBuilder<K, V> {
   ///
   /// Right:
   ///   `new SetMultimapBuilder<int, String>({1: ['1'], 2: ['2'], 3: ['3']})`,
-  ///
-  /// Rejects nulls. Rejects keys and values of the wrong type.
   factory SetMultimapBuilder([multimap = const {}]) {
     return SetMultimapBuilder<K, V>._uninitialized()..replace(multimap);
   }
@@ -111,8 +109,6 @@ class SetMultimapBuilder<K, V> {
   /// As [SetMultimap.add].
   void add(K key, V value) {
     _makeWriteableCopy();
-    _checkKey(key);
-    _checkValue(value);
     _getValuesBuilder(key).add(value);
   }
 
@@ -212,18 +208,6 @@ class SetMultimapBuilder<K, V> {
     if (V == dynamic) {
       throw UnsupportedError('explicit value type required, '
           'for example "new SetMultimapBuilder<int, int>"');
-    }
-  }
-
-  void _checkKey(K key) {
-    if (identical(key, null)) {
-      throw ArgumentError('invalid key: $key');
-    }
-  }
-
-  void _checkValue(V value) {
-    if (identical(value, null)) {
-      throw ArgumentError('invalid value: $value');
     }
   }
 }

--- a/test/set_multimap/built_set_multimap_test.dart
+++ b/test/set_multimap/built_set_multimap_test.dart
@@ -2,11 +2,11 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-library built_collection.test.set_multimap.built_set_multimap_test;
+library built_collection.test.list_multimap.built_list_multimap_test;
 
-import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:built_collection/src/set.dart';
 import 'package:built_collection/src/set_multimap.dart';
+import 'package:built_collection/src/internal/test_helpers.dart';
 import 'package:test/test.dart';
 
 import '../performance.dart';
@@ -151,8 +151,23 @@ void main() {
           throwsA(anything));
     });
 
+    test('nullable does not throw on null keys', () {
+      expect(
+          BuiltSetMultimap<int?, String>({
+            null: ['1']
+          }).asMap(),
+          {
+            null: ['1']
+          });
+    });
+
     test('throws on null value iterables', () {
       expect(() => BuiltSetMultimap<int, String>({1: null}), throwsA(anything));
+    });
+
+    test('nullable also throws on null value iterables', () {
+      expect(
+          () => BuiltSetMultimap<int, String?>({1: null}), throwsA(anything));
     });
 
     test('throws on null values', () {
@@ -161,6 +176,16 @@ void main() {
                 1: [null]
               }),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null values', () {
+      expect(
+          BuiltSetMultimap<int, String?>({
+            1: [null]
+          }).asMap(),
+          {
+            1: [null]
+          });
     });
 
     test('hashes to same value for same contents', () {

--- a/test/set_multimap/set_multimap_builder_test.dart
+++ b/test/set_multimap/set_multimap_builder_test.dart
@@ -29,13 +29,25 @@ void main() {
     });
 
     test('throws on null key add', () {
-      expect(() => SetMultimapBuilder<int, String>().add(null as int, '0'),
+      expect(() => SetMultimapBuilder<int, String>().add(null as dynamic, '0'),
           throwsA(anything));
     });
 
+    test('nullable does not throw on null key add', () {
+      var builder = SetMultimapBuilder<int?, String>();
+      builder.add(null, '0');
+      expect(builder.build()[null], {'0'});
+    });
+
     test('throws on null value add', () {
-      expect(() => SetMultimapBuilder<int, String>().add(0, null as String),
+      expect(() => SetMultimapBuilder<int, String>().add(0, null as dynamic),
           throwsA(anything));
+    });
+
+    test('nullable does not throw on null value add', () {
+      var builder = SetMultimapBuilder<int, String?>();
+      builder.add(0, null);
+      expect(builder.build()[0], {null});
     });
 
     test('throws on wrong type value addValues', () {


### PR DESCRIPTION
Rely on language checks instead. This allows a `BuiltSetMultimap<K?, V?>` to contain nulls.