### PR TITLE
Rename Map.build() to Map.toBuiltMap()

### DIFF
--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -207,5 +207,4 @@ extension BuiltMapExtension<K, V> on Map<K, V> {
   
   /// Converts to a [BuiltMap].
   BuiltMap<K, V> toBuiltMap() => build()
-
 }

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -203,8 +203,8 @@ class _BuiltMap<K, V> extends BuiltMap<K, V> {
 extension BuiltMapExtension<K, V> on Map<K, V> {
   /// Converts to a [BuiltMap].
   @Deprecated('Use toBuiltMap()')
-  BuiltMap<K, V> build() => BuiltMap<K, V>.of(this);
+  BuiltMap<K, V> build() => toBuiltMap();
   
   /// Converts to a [BuiltMap].
-  BuiltMap<K, V> toBuiltMap() => build()
+  BuiltMap<K, V> toBuiltMap() => BuiltMap<K, V>.of(this);
 }

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -202,9 +202,10 @@ class _BuiltMap<K, V> extends BuiltMap<K, V> {
 /// Extensions for [BuiltMap] on [Map].
 extension BuiltMapExtension<K, V> on Map<K, V> {
   /// Converts to a [BuiltMap].
-  @Deprecated('Use toBuiltMap()')
-  BuiltMap<K, V> build() => toBuiltMap();
-  
+  BuiltMap<K, V> build() => BuiltMap<K, V>.of(this);
+}
+
+extension IterableMapEntryExtension<K, V> on Iterable<MapEntry<K, V>> {
   /// Converts to a [BuiltMap].
-  BuiltMap<K, V> toBuiltMap() => BuiltMap<K, V>.of(this);
+  BuiltMap<K, V> toBuiltMap() => Map<K, V>.fromEntries(this).build();
 }

--- a/lib/src/map/built_map.dart
+++ b/lib/src/map/built_map.dart
@@ -202,5 +202,10 @@ class _BuiltMap<K, V> extends BuiltMap<K, V> {
 /// Extensions for [BuiltMap] on [Map].
 extension BuiltMapExtension<K, V> on Map<K, V> {
   /// Converts to a [BuiltMap].
+  @Deprecated('Use toBuiltMap()')
   BuiltMap<K, V> build() => BuiltMap<K, V>.of(this);
+  
+  /// Converts to a [BuiltMap].
+  BuiltMap<K, V> toBuiltMap() => build()
+
 }

--- a/test/map/built_map_test.dart
+++ b/test/map/built_map_test.dart
@@ -423,6 +423,19 @@ void main() {
       expect(
           {1: '1', 2: '2', 3: '3'}.build().toMap(), {1: '1', 2: '2', 3: '3'});
     });
+    test('can be created from `Iterable<MapEntry>` using extension methods',
+        () {
+      expect(
+        [MapEntry(1, '1'), MapEntry(2, '2'), MapEntry(3, '3')].toBuiltMap(),
+        const TypeMatcher<BuiltMap<int, String>>(),
+      );
+      expect(
+        [MapEntry(1, '1'), MapEntry(2, '2'), MapEntry(3, '3')]
+            .toBuiltMap()
+            .toMap(),
+        {1: '1', 2: '2', 3: '3'},
+      );
+    });
   });
 }
 


### PR DESCRIPTION
List extension is `List.toBuiltList()`

When trying to discover the Map equivalent, it's hard to find because it's `Map.build()`. 

This PR aliases `Map.toBuiltMap()` to `Map.build()` and deprecates the latter.

This will unify the naming convention with `List.toBuiltList()` and improve discoverability of the Map to BuiltMap converting extension