### PR TITLE
Add `contains` methods to built multimaps.

### DIFF
--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -118,6 +118,10 @@ abstract class BuiltListMultimap<K, V> {
   /// As [ListMultimap.containsValue].
   bool containsValue(Object? value) => values.contains(value);
 
+  /// As [ListMultimap.contains].
+  bool contains(Object? key, Object? value)
+    => _map[key]?.contains(value) == true;
+
   /// As [ListMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -118,6 +118,10 @@ abstract class BuiltSetMultimap<K, V> {
   /// As [SetMultimap.containsValue].
   bool containsValue(Object? value) => values.contains(value);
 
+  /// As [SetMultimap.contains].
+  bool contains(Object? key, Object? value)
+    => _map[key]?.contains(value) == true;
+
   /// As [SetMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {

--- a/test/list_multimap/built_list_multimap_test.dart
+++ b/test/list_multimap/built_list_multimap_test.dart
@@ -539,6 +539,30 @@ void main() {
           isFalse);
     });
 
+    test('has a method like ListMultimap.contains', () {
+      expect(
+          BuiltListMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(1, '1'),
+          isTrue);
+      expect(
+          BuiltListMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(4, '1'),
+          isFalse);
+      expect(
+          BuiltListMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(2, '3'),
+          isFalse);
+    });
+
     test('has a method like ListMultimap.forEach', () {
       var totalKeys = 0;
       var concatenatedValues = '';

--- a/test/set_multimap/built_set_multimap_test.dart
+++ b/test/set_multimap/built_set_multimap_test.dart
@@ -537,6 +537,30 @@ void main() {
           isFalse);
     });
 
+    test('has a method like SetMultimap.contains', () {
+      expect(
+          BuiltSetMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(1, '1'),
+          isTrue);
+      expect(
+          BuiltSetMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(4, '1'),
+          isFalse);
+      expect(
+          BuiltSetMultimap<int, String>({
+            1: ['1'],
+            2: ['2'],
+            3: ['3']
+          }).contains(2, '3'),
+          isFalse);
+    });
+
     test('has a method like SetMultimap.forEach', () {
       var totalKeys = 0;
       var concatenatedValues = '';


### PR DESCRIPTION
Both `ListMultimap` and `SetMultimap` from quiver support a `contains` operations which checks for the presence of a key/value pair.