### PR TITLE
Updates, tweaks, and fixes for copy-on-write behavior.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml

--- a/benchmark/lib/benchmark.dart
+++ b/benchmark/lib/benchmark.dart
@@ -32,7 +32,7 @@ class BuiltCollectionBenchmark {
       Iterable<int> list = List<int>.generate(1000, (x) => x);
       var fastLazyIterable = list.map((x) => x + 1);
       var slowLazyIterable = list.map(_shortDelay);
-      var builderFactory = () => ListBuilder<int>()..addAll(list);
+      builderFactory() => ListBuilder<int>()..addAll(list);
 
       _benchmark('ListBuilder.$name,list', function, builderFactory, list);
       _benchmark('ListBuilder.$name,fast lazy iterable', function,
@@ -50,7 +50,7 @@ class BuiltCollectionBenchmark {
       Iterable<int> list = List<int>.generate(1000, (x) => x);
       var fastLazyIterable = list.map((x) => x + 1);
       var slowLazyIterable = list.map(_shortDelay);
-      var builderFactory = () => SetBuilder<int>();
+      builderFactory() => SetBuilder<int>();
 
       _benchmark('SetBuilder.$name,list', function, builderFactory, list);
       _benchmark('SetBuilder.$name,fast lazy iterable', function,

--- a/benchmark/pubspec.yaml
+++ b/benchmark/pubspec.yaml
@@ -8,6 +8,10 @@ publish_to: none
 environment:
   sdk: '>=2.12.0 <4.0.0'
 
+dependencies:
+  built_collection:
+    path: ..    
+
 dev_dependencies:
   build_runner: any
   build_test: any

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -4,9 +4,12 @@ description: >
   Example, not for publishing.
 homepage: https://github.com/google/built_collection.dart
 
+# This package is not intended for consumption on pub.dev. DO NOT publish.
+publish_to: none
+
 environment:
   sdk: '>=2.12.0 <4.0.0'
 
-dependency_overrides:
+dependencies:
   built_collection:
     path: ..

--- a/lib/built_collection.dart
+++ b/lib/built_collection.dart
@@ -104,9 +104,10 @@
 /// a copy, but return a copy-on-write wrapper. So, Built Collections can be
 /// efficiently and easily used with code that needs core SDK collections but
 /// does not mutate them.
+library;
 
-export 'src/list.dart' hide OverriddenHashcodeBuiltList;
-export 'src/list_multimap.dart' hide OverriddenHashcodeBuiltListMultimap;
-export 'src/map.dart' hide OverriddenHashcodeBuiltMap;
-export 'src/set.dart' hide OverriddenHashcodeBuiltSet;
-export 'src/set_multimap.dart' hide OverriddenHashcodeBuiltSetMultimap;
+export 'src/list.dart' hide OverriddenHashCodeBuiltList;
+export 'src/list_multimap.dart' hide OverriddenHashCodeBuiltListMultimap;
+export 'src/map.dart' hide OverriddenHashCodeBuiltMap;
+export 'src/set.dart' hide OverriddenHashCodeBuiltSet;
+export 'src/set_multimap.dart' hide OverriddenHashCodeBuiltSetMultimap;

--- a/lib/src/internal/copy_on_write_list.dart
+++ b/lib/src/internal/copy_on_write_list.dart
@@ -2,16 +2,20 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'dart:collection' show ListBase;
 import 'dart:math';
 
-class CopyOnWriteList<E> implements List<E> {
+class CopyOnWriteList<E> extends ListBase<E> {
   bool _copyBeforeWrite;
   final bool _growable;
   List<E> _list;
 
   CopyOnWriteList(this._list, this._growable) : _copyBeforeWrite = true;
 
-  // Read-only methods: just forward.
+  // Read-only methods returning values: just forward.
+  // Methods returning a lazy view use default list implementation
+  // until first write, to avoid capturing a `_list` which may be replaced
+  // on a write.
 
   @override
   int get length => _list.length;
@@ -26,10 +30,10 @@ class CopyOnWriteList<E> implements List<E> {
   bool any(bool Function(E) test) => _list.any(test);
 
   @override
-  Map<int, E> asMap() => _list.asMap();
+  Map<int, E> asMap() => _copyBeforeWrite ? super.asMap() : _list.asMap();
 
   @override
-  List<T> cast<T>() => CopyOnWriteList<T>(_list.cast<T>(), _growable);
+  List<T> cast<T>() => _copyBeforeWrite ? super.cast<T>() : _list.cast<T>();
 
   @override
   bool contains(Object? element) => _list.contains(element);
@@ -41,7 +45,8 @@ class CopyOnWriteList<E> implements List<E> {
   bool every(bool Function(E) test) => _list.every(test);
 
   @override
-  Iterable<T> expand<T>(Iterable<T> Function(E) f) => _list.expand(f);
+  Iterable<T> expand<T>(Iterable<T> Function(E) f) =>
+      _copyBeforeWrite ? super.expand<T>(f) : _list.expand(f);
 
   @override
   E get first => _list.first;
@@ -55,16 +60,20 @@ class CopyOnWriteList<E> implements List<E> {
       _list.fold(initialValue, combine);
 
   @override
-  Iterable<E> followedBy(Iterable<E> other) => _list.followedBy(other);
+  Iterable<E> followedBy(Iterable<E> other) =>
+      _copyBeforeWrite ? super.followedBy(other) : _list.followedBy(other);
 
   @override
-  void forEach(void Function(E) f) => _list.forEach(f);
+  void forEach(void Function(E) action) => _list.forEach(action);
 
   @override
-  Iterable<E> getRange(int start, int end) => _list.getRange(start, end);
+  Iterable<E> getRange(int start, int end) => _copyBeforeWrite
+      ? super.getRange(start, end)
+      : _list.getRange(start, end);
 
   @override
-  int indexOf(E element, [int start = 0]) => _list.indexOf(element, start);
+  int indexOf(covariant E element, [int start = 0]) =>
+      _list.indexOf(element, start);
 
   @override
   int indexWhere(bool Function(E) test, [int start = 0]) =>
@@ -77,7 +86,8 @@ class CopyOnWriteList<E> implements List<E> {
   bool get isNotEmpty => _list.isNotEmpty;
 
   @override
-  Iterator<E> get iterator => _list.iterator;
+  Iterator<E> get iterator =>
+      _copyBeforeWrite ? super.iterator : _list.iterator;
 
   @override
   String join([String separator = '']) => _list.join(separator);
@@ -86,7 +96,8 @@ class CopyOnWriteList<E> implements List<E> {
   E get last => _list.last;
 
   @override
-  int lastIndexOf(E element, [int? start]) => _list.lastIndexOf(element, start);
+  int lastIndexOf(covariant E element, [int? start]) =>
+      _list.lastIndexOf(element, start);
 
   @override
   int lastIndexWhere(bool Function(E) test, [int? start]) =>
@@ -97,13 +108,15 @@ class CopyOnWriteList<E> implements List<E> {
       _list.lastWhere(test, orElse: orElse);
 
   @override
-  Iterable<T> map<T>(T Function(E) f) => _list.map(f);
+  Iterable<T> map<T>(T Function(E) f) =>
+      _copyBeforeWrite ? super.map(f) : _list.map(f);
 
   @override
   E reduce(E Function(E, E) combine) => _list.reduce(combine);
 
   @override
-  Iterable<E> get reversed => _list.reversed;
+  Iterable<E> get reversed =>
+      _copyBeforeWrite ? super.reversed : _list.reversed;
 
   @override
   E get single => _list.single;
@@ -113,19 +126,23 @@ class CopyOnWriteList<E> implements List<E> {
       _list.singleWhere(test, orElse: orElse);
 
   @override
-  Iterable<E> skip(int count) => _list.skip(count);
+  Iterable<E> skip(int count) =>
+      _copyBeforeWrite ? super.skip(count) : _list.skip(count);
 
   @override
-  Iterable<E> skipWhile(bool Function(E) test) => _list.skipWhile(test);
+  Iterable<E> skipWhile(bool Function(E) test) =>
+      _copyBeforeWrite ? super.skipWhile(test) : _list.skipWhile(test);
 
   @override
   List<E> sublist(int start, [int? end]) => _list.sublist(start, end);
 
   @override
-  Iterable<E> take(int count) => _list.take(count);
+  Iterable<E> take(int count) =>
+      _copyBeforeWrite ? super.take(count) : _list.take(count);
 
   @override
-  Iterable<E> takeWhile(bool Function(E) test) => _list.takeWhile(test);
+  Iterable<E> takeWhile(bool Function(E) test) =>
+      _copyBeforeWrite ? super.takeWhile(test) : _list.takeWhile(test);
 
   @override
   List<E> toList({bool growable = true}) => _list.toList(growable: growable);
@@ -134,10 +151,12 @@ class CopyOnWriteList<E> implements List<E> {
   Set<E> toSet() => _list.toSet();
 
   @override
-  Iterable<E> where(bool Function(E) test) => _list.where(test);
+  Iterable<E> where(bool Function(E) test) =>
+      _copyBeforeWrite ? super.where(test) : _list.where(test);
 
   @override
-  Iterable<T> whereType<T>() => _list.whereType<T>();
+  Iterable<T> whereType<T>() =>
+      _copyBeforeWrite ? super.whereType<T>() : _list.whereType<T>();
 
   // Mutating methods: copy first if needed.
 
@@ -166,9 +185,9 @@ class CopyOnWriteList<E> implements List<E> {
   }
 
   @override
-  void add(E value) {
+  void add(E element) {
     _maybeCopyBeforeWrite();
-    _list.add(value);
+    _list.add(element);
   }
 
   @override
@@ -214,9 +233,9 @@ class CopyOnWriteList<E> implements List<E> {
   }
 
   @override
-  bool remove(Object? value) {
+  bool remove(Object? element) {
     _maybeCopyBeforeWrite();
-    return _list.remove(value);
+    return _list.remove(element);
   }
 
   @override
@@ -256,15 +275,15 @@ class CopyOnWriteList<E> implements List<E> {
   }
 
   @override
-  void fillRange(int start, int end, [E? fillValue]) {
+  void fillRange(int start, int end, [E? fill]) {
     _maybeCopyBeforeWrite();
-    _list.fillRange(start, end, fillValue);
+    _list.fillRange(start, end, fill);
   }
 
   @override
-  void replaceRange(int start, int end, Iterable<E> iterable) {
+  void replaceRange(int start, int end, Iterable<E> newContents) {
     _maybeCopyBeforeWrite();
-    _list.replaceRange(start, end, iterable);
+    _list.replaceRange(start, end, newContents);
   }
 
   @override
@@ -275,6 +294,6 @@ class CopyOnWriteList<E> implements List<E> {
   void _maybeCopyBeforeWrite() {
     if (!_copyBeforeWrite) return;
     _copyBeforeWrite = false;
-    _list = List<E>.from(_list, growable: _growable);
+    _list = List<E>.of(_list, growable: _growable);
   }
 }

--- a/lib/src/internal/copy_on_write_map.dart
+++ b/lib/src/internal/copy_on_write_map.dart
@@ -2,10 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-typedef _MapFactory<K, V> = Map<K, V> Function();
-
 class CopyOnWriteMap<K, V> implements Map<K, V> {
-  final _MapFactory<K, V>? _mapFactory;
+  final Map<K, V> Function()? _mapFactory;
   bool _copyBeforeWrite;
   Map<K, V> _map;
 
@@ -115,6 +113,6 @@ class CopyOnWriteMap<K, V> implements Map<K, V> {
     _copyBeforeWrite = false;
     _map = _mapFactory != null
         ? (_mapFactory!()..addAll(_map))
-        : Map<K, V>.from(_map);
+        : Map<K, V>.of(_map);
   }
 }

--- a/lib/src/internal/test_helpers.dart
+++ b/lib/src/internal/test_helpers.dart
@@ -12,35 +12,35 @@ import '../set_multimap.dart';
 class BuiltCollectionTestHelpers {
   static BuiltList<int> overridenHashcodeBuiltList(
           Iterable iterable, int hashCode) =>
-      OverriddenHashcodeBuiltList<int>(iterable, hashCode);
+      OverriddenHashCodeBuiltList<int>(iterable, hashCode);
 
   static BuiltListMultimap<int, String> overridenHashcodeBuiltListMultimap(
           Object map, int hashCode) =>
-      OverriddenHashcodeBuiltListMultimap<int, String>(map, hashCode);
+      OverriddenHashCodeBuiltListMultimap<int, String>(map, hashCode);
 
   static BuiltListMultimap<String, String>
       overridenHashcodeBuiltListMultimapWithStringKeys(
               Object map, int hashCode) =>
-          OverriddenHashcodeBuiltListMultimap<String, String>(map, hashCode);
+          OverriddenHashCodeBuiltListMultimap<String, String>(map, hashCode);
 
   static BuiltMap<int, String> overridenHashcodeBuiltMap(
           Object map, int hashCode) =>
-      OverriddenHashcodeBuiltMap<int, String>(map, hashCode);
+      OverriddenHashCodeBuiltMap<int, String>(map, hashCode);
 
   static BuiltMap<String, String> overridenHashcodeBuiltMapWithStringKeys(
           Object map, int hashCode) =>
-      OverriddenHashcodeBuiltMap<String, String>(map, hashCode);
+      OverriddenHashCodeBuiltMap<String, String>(map, hashCode);
 
   static BuiltSet<int> overridenHashcodeBuiltSet(
           Iterable iterable, int hashCode) =>
-      OverriddenHashcodeBuiltSet<int>(iterable, hashCode);
+      OverriddenHashCodeBuiltSet<int>(iterable, hashCode);
 
   static BuiltSetMultimap<int, String> overridenHashcodeBuiltSetMultimap(
           Object map, int hashCode) =>
-      OverriddenHashcodeBuiltSetMultimap<int, String>(map, hashCode);
+      OverriddenHashCodeBuiltSetMultimap<int, String>(map, hashCode);
 
   static BuiltSetMultimap<String, String>
       overridenHashcodeBuiltSetMultimapWithStringKeys(
               Object map, int hashCode) =>
-          OverriddenHashcodeBuiltSetMultimap<String, String>(map, hashCode);
+          OverriddenHashCodeBuiltSetMultimap<String, String>(map, hashCode);
 }

--- a/lib/src/internal/type_helper.dart
+++ b/lib/src/internal/type_helper.dart
@@ -1,0 +1,11 @@
+// Copyright (c) 2025, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Only used to test if a type parameter [T] is a subtype of some other type.
+///
+/// The only language-level operation for that is `is` which requires an
+/// object.
+class TypeHelper<T> {}
+
+class TypeHelper2<K, V> {}

--- a/lib/src/list.dart
+++ b/lib/src/list.dart
@@ -11,18 +11,19 @@ import 'internal/copy_on_write_list.dart';
 import 'internal/hash.dart';
 import 'internal/iterables.dart';
 import 'internal/null_safety.dart';
+import 'internal/type_helper.dart';
 
 part 'list/built_list.dart';
 part 'list/list_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltList<T> extends _BuiltList<T> {
-  final int _overridenHashCode;
+class OverriddenHashCodeBuiltList<T> extends _BuiltList<T> {
+  final int _overriddenHashCode;
 
-  OverriddenHashcodeBuiltList(Iterable iterable, this._overridenHashCode)
-      : super.from(iterable);
+  OverriddenHashCodeBuiltList(super.iterable, this._overriddenHashCode)
+      : super.from();
 
   @override
   // ignore: hash_and_equals
-  int get hashCode => _overridenHashCode;
+  int get hashCode => _overriddenHashCode;
 }

--- a/lib/src/list/built_list.dart
+++ b/lib/src/list/built_list.dart
@@ -19,7 +19,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
   /// Instantiates with elements from an [Iterable].
   factory BuiltList([Iterable iterable = const []]) {
-    if (iterable is _BuiltList && iterable.hasExactElementType(E)) {
+    if (iterable is _BuiltList && iterable.hasEquivalentElementType<E>()) {
       return iterable as BuiltList<E>;
     } else {
       return _BuiltList<E>.from(iterable);
@@ -30,7 +30,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   ///
   /// `E` must not be `dynamic`.
   factory BuiltList.of(Iterable<E> iterable) {
-    if (iterable is _BuiltList<E> && iterable.hasExactElementType(E)) {
+    if (iterable is _BuiltList<E> && iterable.hasEquivalentElementType<E>()) {
       return iterable;
     } else {
       return _BuiltList<E>.of(iterable);
@@ -61,10 +61,7 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
   /// A `BuiltList` is only equal to another `BuiltList` with equal elements in
   /// the same order. Then, the `hashCode` is guaranteed to be the same.
   @override
-  int get hashCode {
-    _hashCode ??= hashObjects(_list);
-    return _hashCode!;
-  }
+  int get hashCode => _hashCode ??= hashObjects(_list);
 
   /// Deep equality.
   ///
@@ -239,30 +236,16 @@ abstract class BuiltList<E> implements Iterable<E>, BuiltIterable<E> {
 
 /// Default implementation of the public [BuiltList] interface.
 class _BuiltList<E> extends BuiltList<E> {
-  _BuiltList.withSafeList(List<E> list) : super._(list);
+  _BuiltList.withSafeList(super.list) : super._();
 
   _BuiltList.from([Iterable iterable = const []])
-      : super._(List<E>.from(iterable, growable: false)) {
-    _maybeCheckForNull();
-  }
+      : super._(List<E>.from(iterable, growable: false));
 
   _BuiltList.of(Iterable<E> iterable)
-      : super._(List<E>.from(iterable, growable: false)) {
-    _maybeCheckForNull();
-  }
+      : super._(List<E>.from(iterable, growable: false));
 
-  bool get _needsNullCheck => !isSoundMode && null is! E;
-
-  void _maybeCheckForNull() {
-    if (!_needsNullCheck) return;
-    for (var element in _list) {
-      if (identical(element, null)) {
-        throw ArgumentError('iterable contained invalid element: null');
-      }
-    }
-  }
-
-  bool hasExactElementType(Type type) => E == type;
+  bool hasEquivalentElementType<T>() =>
+      this is _BuiltList<T> && TypeHelper<T>() is TypeHelper<E>;
 }
 
 /// Extensions for [BuiltList] on [List].

--- a/lib/src/list/list_builder.dart
+++ b/lib/src/list/list_builder.dart
@@ -284,7 +284,7 @@ class ListBuilder<E> {
 
   List<E> get _safeList {
     if (_listOwner != null) {
-      _setSafeList(List<E>.from(_list, growable: true));
+      _setSafeList(List<E>.of(_list, growable: true));
     }
     return _list;
   }

--- a/lib/src/list_multimap.dart
+++ b/lib/src/list_multimap.dart
@@ -6,17 +6,18 @@ import 'internal/copy_on_write_map.dart';
 
 import 'internal/hash.dart';
 import 'internal/null_safety.dart';
+import 'internal/type_helper.dart';
 import 'list.dart';
 
 part 'list_multimap/built_list_multimap.dart';
 part 'list_multimap/list_multimap_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltListMultimap<K, V>
+class OverriddenHashCodeBuiltListMultimap<K, V>
     extends _BuiltListMultimap<K, V> {
   final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltListMultimap(map, this._overridenHashCode)
+  OverriddenHashCodeBuiltListMultimap(map, this._overridenHashCode)
       : super.copy(map.keys, (k) => map[k]);
 
   @override

--- a/lib/src/list_multimap/built_list_multimap.dart
+++ b/lib/src/list_multimap/built_list_multimap.dart
@@ -29,7 +29,7 @@ abstract class BuiltListMultimap<K, V> {
   /// [BuiltListMultimap].
   factory BuiltListMultimap([multimap = const {}]) {
     if (multimap is _BuiltListMultimap &&
-        multimap.hasExactKeyAndValueTypes(K, V)) {
+        multimap.hasEquivalentKeyAndValueTypes<K, V>()) {
       return multimap as BuiltListMultimap<K, V>;
     } else if (multimap is Map) {
       return _BuiltListMultimap<K, V>.copy(multimap.keys, (k) => multimap[k]);
@@ -121,9 +121,9 @@ abstract class BuiltListMultimap<K, V> {
   /// As [ListMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {
-      values.forEach((value) {
+      for (var value in values) {
         f(key, value);
-      });
+      }
     });
   }
 
@@ -164,7 +164,7 @@ abstract class BuiltListMultimap<K, V> {
 
 /// Default implementation of the public [BuiltListMultimap] interface.
 class _BuiltListMultimap<K, V> extends BuiltListMultimap<K, V> {
-  _BuiltListMultimap.withSafeMap(Map<K, BuiltList<V>> map) : super._(map);
+  _BuiltListMultimap.withSafeMap(super.map) : super._();
 
   _BuiltListMultimap.copy(Iterable keys, Function lookup)
       : super._(<K, BuiltList<V>>{}) {
@@ -177,5 +177,7 @@ class _BuiltListMultimap<K, V> extends BuiltListMultimap<K, V> {
     }
   }
 
-  bool hasExactKeyAndValueTypes(Type key, Type value) => K == key && V == value;
+  bool hasEquivalentKeyAndValueTypes<K2, V2>() =>
+      this is _BuiltListMultimap<K2, V2> &&
+      TypeHelper2<K2, V2>() is TypeHelper2<K, V>;
 }

--- a/lib/src/list_multimap/list_multimap_builder.dart
+++ b/lib/src/list_multimap/list_multimap_builder.dart
@@ -111,9 +111,9 @@ class ListMultimapBuilder<K, V> {
   /// As [ListMultimap.addValues].
   void addValues(K key, Iterable<V> values) {
     // _disown is called in add.
-    values.forEach((value) {
+    for (var value in values) {
       add(key, value);
-    });
+    }
   }
 
   /// As [ListMultimap.remove].
@@ -171,7 +171,7 @@ class ListMultimapBuilder<K, V> {
 
   void _makeWriteableCopy() {
     if (_builtMapOwner != null) {
-      _builtMap = Map<K, BuiltList<V>>.from(_builtMap);
+      _builtMap = Map<K, BuiltList<V>>.of(_builtMap);
       _builtMapOwner = null;
     }
   }

--- a/lib/src/map.dart
+++ b/lib/src/map.dart
@@ -5,18 +5,19 @@
 import 'internal/copy_on_write_map.dart';
 import 'internal/hash.dart';
 import 'internal/null_safety.dart';
+import 'internal/type_helper.dart';
 
 part 'map/built_map.dart';
 part 'map/map_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltMap<K, V> extends _BuiltMap<K, V> {
-  final int _overrridenHashCode;
+class OverriddenHashCodeBuiltMap<K, V> extends _BuiltMap<K, V> {
+  final int _overriddenHashCode;
 
-  OverriddenHashcodeBuiltMap(map, this._overrridenHashCode)
+  OverriddenHashCodeBuiltMap(map, this._overriddenHashCode)
       : super.copyAndCheckTypes(map.keys, (k) => map[k]);
 
   @override
   // ignore: hash_and_equals
-  int get hashCode => _overrridenHashCode;
+  int get hashCode => _overriddenHashCode;
 }

--- a/lib/src/map/map_builder.dart
+++ b/lib/src/map/map_builder.dart
@@ -13,7 +13,7 @@ part of '../map.dart';
 /// for the general properties of Built Collections.
 class MapBuilder<K, V> {
   /// Used by [_createMap] to instantiate [_map]. The default value is `null`.
-  _MapFactory<K, V>? _mapFactory;
+  Map<K, V> Function()? _mapFactory;
   late Map<K, V> _map;
   _BuiltMap<K, V>? _mapOwner;
 
@@ -73,7 +73,7 @@ class MapBuilder<K, V> {
   /// instantiate and return a new object.
   ///
   /// Use [withDefaultBase] to reset `base` to the default value.
-  void withBase(_MapFactory<K, V> base) {
+  void withBase(Map<K, V> Function() base) {
     ArgumentError.checkNotNull(base, 'base');
     _mapFactory = base;
     _setSafeMap(_createMap()..addAll(_map));

--- a/lib/src/set.dart
+++ b/lib/src/set.dart
@@ -9,19 +9,20 @@ import 'internal/hash.dart';
 import 'internal/copy_on_write_set.dart';
 import 'internal/iterables.dart';
 import 'internal/null_safety.dart';
+import 'internal/type_helper.dart';
 import 'internal/unmodifiable_set.dart';
 
 part 'set/built_set.dart';
 part 'set/set_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltSet<T> extends _BuiltSet<T> {
-  final int _overridenHashCode;
+class OverriddenHashCodeBuiltSet<T> extends _BuiltSet<T> {
+  final int _overriddenHashCode;
 
-  OverriddenHashcodeBuiltSet(Iterable iterable, this._overridenHashCode)
-      : super.from(iterable);
+  OverriddenHashCodeBuiltSet(super.iterable, this._overriddenHashCode)
+      : super.from();
 
   @override
   // ignore: hash_and_equals
-  int get hashCode => _overridenHashCode;
+  int get hashCode => _overriddenHashCode;
 }

--- a/lib/src/set/built_set.dart
+++ b/lib/src/set/built_set.dart
@@ -4,8 +4,6 @@
 
 part of '../set.dart';
 
-typedef _SetFactory<E> = Set<E> Function();
-
 /// The Built Collection [Set].
 ///
 /// It implements [Iterable] and the non-mutating part of the [Set] interface.
@@ -16,16 +14,17 @@ typedef _SetFactory<E> = Set<E> Function();
 /// [Built Collection library documentation](#built_collection/built_collection)
 /// for the general properties of Built Collections.
 abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
-  final _SetFactory<E>? _setFactory;
+  final Set<E> Function()? _setFactory;
   final Set<E> _set;
   int? _hashCode;
 
   /// Instantiates with elements from an [Iterable].
-  factory BuiltSet([Iterable iterable = const []]) => BuiltSet.from(iterable);
+  factory BuiltSet([Iterable iterable = const []]) =>
+      BuiltSet<E>.from(iterable);
 
   /// Instantiates with elements from an [Iterable].
   factory BuiltSet.from(Iterable iterable) {
-    if (iterable is _BuiltSet && iterable.hasExactElementType(E)) {
+    if (iterable is _BuiltSet && iterable.hasEquivalentElementType<E>()) {
       return iterable as BuiltSet<E>;
     } else {
       return _BuiltSet<E>.from(iterable);
@@ -34,7 +33,7 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
   /// Instantiates with elements from an [Iterable<E>].
   factory BuiltSet.of(Iterable<E> iterable) {
-    if (iterable is _BuiltSet<E> && iterable.hasExactElementType(E)) {
+    if (iterable is _BuiltSet<E> && iterable.hasEquivalentElementType<E>()) {
       return iterable;
     } else {
       return _BuiltSet<E>.of(iterable);
@@ -228,29 +227,14 @@ abstract class BuiltSet<E> implements Iterable<E>, BuiltIterable<E> {
 
 /// Default implementation of the public [BuiltSet] interface.
 class _BuiltSet<E> extends BuiltSet<E> {
-  _BuiltSet.withSafeSet(_SetFactory<E>? setFactory, Set<E> set)
-      : super._(setFactory, set);
+  _BuiltSet.withSafeSet(super.setFactory, super.set) : super._();
 
-  _BuiltSet.from(Iterable iterable) : super._(null, Set<E>.from(iterable)) {
-    _maybeCheckForNull();
-  }
+  _BuiltSet.from(Iterable iterable) : super._(null, Set<E>.from(iterable));
 
-  _BuiltSet.of(Iterable<E> iterable) : super._(null, <E>{}..addAll(iterable)) {
-    _maybeCheckForNull();
-  }
+  _BuiltSet.of(Iterable<E> iterable) : super._(null, <E>{}..addAll(iterable));
 
-  bool get _needsNullCheck => !isSoundMode && null is! E;
-
-  void _maybeCheckForNull() {
-    if (!_needsNullCheck) return;
-    for (var element in _set) {
-      if (identical(element, null)) {
-        throw ArgumentError('iterable contained invalid element: null');
-      }
-    }
-  }
-
-  bool hasExactElementType(Type type) => E == type;
+  bool hasEquivalentElementType<T>() =>
+      this is _BuiltSet<T> && TypeHelper<T>() is TypeHelper<E>;
 }
 
 /// Extensions for [BuiltSet] on [Set].

--- a/lib/src/set/set_builder.dart
+++ b/lib/src/set/set_builder.dart
@@ -13,7 +13,7 @@ part of '../set.dart';
 /// for the general properties of Built Collections.
 class SetBuilder<E> {
   /// Used by [_createSet] to instantiate [_set]. The default value is `null`.
-  _SetFactory<E>? _setFactory;
+  Set<E> Function()? _setFactory;
   late Set<E> _set;
   _BuiltSet<E>? _setOwner;
 
@@ -84,7 +84,7 @@ class SetBuilder<E> {
   /// same type.
   ///
   /// Use [withDefaultBase] to reset `base` to the default value.
-  void withBase(_SetFactory<E> base) {
+  void withBase(Set<E> Function() base) {
     ArgumentError.checkNotNull(base, 'base');
     _setFactory = base;
     _setSafeSet(_createSet()..addAll(_set));

--- a/lib/src/set_multimap.dart
+++ b/lib/src/set_multimap.dart
@@ -5,6 +5,7 @@
 import 'internal/copy_on_write_map.dart';
 import 'internal/hash.dart';
 import 'internal/null_safety.dart';
+import 'internal/type_helper.dart';
 
 import 'set.dart';
 
@@ -12,10 +13,10 @@ part 'set_multimap/built_set_multimap.dart';
 part 'set_multimap/set_multimap_builder.dart';
 
 // Internal only, for testing.
-class OverriddenHashcodeBuiltSetMultimap<K, V> extends _BuiltSetMultimap<K, V> {
+class OverriddenHashCodeBuiltSetMultimap<K, V> extends _BuiltSetMultimap<K, V> {
   final int _overridenHashCode;
 
-  OverriddenHashcodeBuiltSetMultimap(map, this._overridenHashCode)
+  OverriddenHashCodeBuiltSetMultimap(map, this._overridenHashCode)
       : super.copyAndCheck(map.keys, (k) => map[k]);
 
   @override

--- a/lib/src/set_multimap/built_set_multimap.dart
+++ b/lib/src/set_multimap/built_set_multimap.dart
@@ -28,7 +28,7 @@ abstract class BuiltSetMultimap<K, V> {
   /// [BuiltSetMultimap].
   factory BuiltSetMultimap([multimap = const {}]) {
     if (multimap is _BuiltSetMultimap &&
-        multimap.hasExactKeyAndValueTypes(K, V)) {
+        multimap.hasEquivalentKeyAndValueTypes<K, V>()) {
       return multimap as BuiltSetMultimap<K, V>;
     } else if (multimap is Map) {
       return _BuiltSetMultimap<K, V>.copyAndCheck(
@@ -121,9 +121,9 @@ abstract class BuiltSetMultimap<K, V> {
   /// As [SetMultimap.forEach].
   void forEach(void Function(K, V) f) {
     _map.forEach((key, values) {
-      values.forEach((value) {
+      for (var value in values) {
         f(key, value);
-      });
+      }
     });
   }
 
@@ -164,7 +164,7 @@ abstract class BuiltSetMultimap<K, V> {
 
 /// Default implementation of the public [BuiltSetMultimap] interface.
 class _BuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
-  _BuiltSetMultimap.withSafeMap(Map<K, BuiltSet<V>> map) : super._(map);
+  _BuiltSetMultimap.withSafeMap(super.map) : super._();
 
   _BuiltSetMultimap.copyAndCheck(Iterable keys, Function lookup)
       : super._(<K, BuiltSet<V>>{}) {
@@ -177,5 +177,7 @@ class _BuiltSetMultimap<K, V> extends BuiltSetMultimap<K, V> {
     }
   }
 
-  bool hasExactKeyAndValueTypes(Type key, Type value) => K == key && V == value;
+  bool hasEquivalentKeyAndValueTypes<K2, V2>() =>
+      this is _BuiltSetMultimap<K2, V2> &&
+      TypeHelper2<K2, V2>() is TypeHelper2<K, V>;
 }

--- a/lib/src/set_multimap/set_multimap_builder.dart
+++ b/lib/src/set_multimap/set_multimap_builder.dart
@@ -106,9 +106,9 @@ class SetMultimapBuilder<K, V> {
   /// As [SetMultimap.addValues].
   void addValues(K key, Iterable<V> values) {
     // _disown is called in add.
-    values.forEach((value) {
+    for (var value in values) {
       add(key, value);
-    });
+    }
   }
 
   /// As [SetMultimap.remove] but returns nothing.
@@ -155,7 +155,7 @@ class SetMultimapBuilder<K, V> {
 
   void _makeWriteableCopy() {
     if (_builtMapOwner != null) {
-      _builtMap = Map<K, BuiltSet<V>>.from(_builtMap);
+      _builtMap = Map<K, BuiltSet<V>>.of(_builtMap);
       _builtMapOwner = null;
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,8 +7,8 @@ description: >
 repository: https://github.com/google/built_collection.dart
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  pedantic: ^1.4.0
-  test: ^1.16.0-nullsafety
+  lints: ^5.0.0
+  test: ^1.25.0

--- a/test/internal/copy_on_write_list_test.dart
+++ b/test/internal/copy_on_write_list_test.dart
@@ -11,5 +11,55 @@ void main() {
       var list = <int>[1, 2, 3];
       expect(CopyOnWriteList(list, false).toString(), list.toString());
     });
+
+    test('has safe lazy behavior', () {
+      var list = <int>[1, 2, 3];
+      var cowList = CopyOnWriteList(list, false);
+      // Once while needing to copy, once while not.
+      for (var i = 1; i <= 2; i++) {
+        var lazyCast = cowList.cast<num>();        
+        var lazyMap = cowList.map((int x) => x);
+        var lazyExpand = cowList.expand((int x) => <int>[x]);
+        var lazyWhere = cowList.where((int x) => true);
+        var lazyWhereType = cowList.whereType<num>();
+        var lazySkip = cowList.skip(0);
+        var lazyTake = cowList.take(10);
+        var lazyGetRange = cowList.getRange(0, cowList.length);
+        var lazySkipWhile = cowList.skipWhile((int x) => false);
+        var lazyTakeWhile = cowList.takeWhile((int x) => true);
+        var lazyFollowedBy = cowList.followedBy(<int>[]);
+        var lazyReversed = cowList.reversed;
+
+        // Write to list.
+        cowList[0] += 1;
+
+        // Iterables agree with list.
+        expect(lazyCast.toList(), cowList.cast<num>().toList());
+        expect(lazyMap.toList(), cowList.map((int x) => x).toList(),
+            reason: "map");
+        expect(
+            lazyExpand.toList(), cowList.expand((int x) => <int>[x]).toList(),
+            reason: "expand");
+        expect(lazyWhere.toList(), cowList.where((int x) => true).toList(),
+            reason: "where");
+        expect(lazyWhereType.toList(), cowList.whereType<num>().toList(),
+            reason: "whereType");
+        expect(lazySkip.toList(), cowList.skip(0).toList(), reason: "skip");
+        expect(lazyTake.toList(), cowList.take(10).toList(), reason: "take");
+        expect(
+            lazyGetRange.toList(), cowList.getRange(0, cowList.length).toList(),
+            reason: "getRange");
+        expect(lazySkipWhile.toList(),
+            cowList.skipWhile((int x) => false).toList(),
+            reason: "skipWhile");
+        expect(
+            lazyTakeWhile.toList(), cowList.takeWhile((int x) => true).toList(),
+            reason: "takeWhile");
+        expect(lazyFollowedBy.toList(), cowList.followedBy(<int>[]).toList(),
+            reason: "followedBy");
+        expect(lazyReversed.toList(), cowList.reversed.toList(),
+            reason: "reversed");
+      }
+    });
   });
 }

--- a/test/internal/copy_on_write_set_test.dart
+++ b/test/internal/copy_on_write_set_test.dart
@@ -11,5 +11,47 @@ void main() {
       var set = <int>{1, 2, 3};
       expect(CopyOnWriteSet(set).toString(), set.toString());
     });
+
+    test('has safe lazy behavior', () {
+      var cowSet = CopyOnWriteSet<int>(<int>{1, 2, 3});
+      // Once while needing to copy, once while not.
+      for (var i = 1; i <= 2; i++) {
+        var lazyCast = cowSet.cast<num>();
+        var lazyMap = cowSet.map((int x) => x);
+        var lazyExpand = cowSet.expand((int x) => <int>[x]);
+        var lazyWhere = cowSet.where((int x) => true);
+        var lazyWhereType = cowSet.whereType<num>();
+        var lazySkip = cowSet.skip(0);
+        var lazyTake = cowSet.take(10);
+        var lazySkipWhile = cowSet.skipWhile((int x) => false);
+        var lazyTakeWhile = cowSet.takeWhile((int x) => true);
+        var lazyFollowedBy = cowSet.followedBy(<int>[]);
+
+        // Write to list.
+        cowSet.add(cowSet.length + 1);
+
+        // Iterables agree with list.
+        expect(lazyCast.toList(), cowSet.cast<num>().toList());
+        expect(lazyMap.toList(), cowSet.map((int x) => x).toList(),
+            reason: "map");
+        expect(
+            lazyExpand.toList(), cowSet.expand((int x) => <int>[x]).toList(),
+            reason: "expand");
+        expect(lazyWhere.toList(), cowSet.where((int x) => true).toList(),
+            reason: "where");
+        expect(lazyWhereType.toList(), cowSet.whereType<num>().toList(),
+            reason: "whereType");
+        expect(lazySkip.toList(), cowSet.skip(0).toList(), reason: "skip");
+        expect(lazyTake.toList(), cowSet.take(10).toList(), reason: "take");
+        expect(lazySkipWhile.toList(),
+            cowSet.skipWhile((int x) => false).toList(),
+            reason: "skipWhile");
+        expect(
+            lazyTakeWhile.toList(), cowSet.takeWhile((int x) => true).toList(),
+            reason: "takeWhile");
+        expect(lazyFollowedBy.toList(), cowSet.followedBy(<int>[]).toList(),
+            reason: "followedBy");
+      }
+    });
   });
 }

--- a/test/list/list_builder_test.dart
+++ b/test/list/list_builder_test.dart
@@ -318,10 +318,9 @@ void main() {
     });
 
     test('converts to BuiltList without copying', () {
-      var makeLongListBuilder =
-          () => ListBuilder<int>(List<int>.filled(1000000, 0));
+      makeLongListBuilder() => ListBuilder<int>(List<int>.filled(1000000, 0));
       var longListBuilder = makeLongListBuilder();
-      var buildLongListBuilder = () => longListBuilder.build();
+      buildLongListBuilder() => longListBuilder.build();
 
       expectMuchFaster(buildLongListBuilder, makeLongListBuilder);
     });

--- a/test/list_multimap/built_list_multimap_test.dart
+++ b/test/list_multimap/built_list_multimap_test.dart
@@ -386,13 +386,14 @@ void main() {
 
     test('converts to ListMultimapBuilder from correct type without copying',
         () {
-      var makeLongListMultimap = () {
+      makeLongListMultimap() {
         var result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longListMultimap = makeLongListMultimap();
       var longListMultimapToListMultimapBuilder = longListMultimap.toBuilder;
 
@@ -401,43 +402,46 @@ void main() {
     });
 
     test('converts to ListMultimapBuilder from wrong type by copying', () {
-      var makeLongListMultimap = () {
+      makeLongListMultimap() {
         var result = ListMultimapBuilder<Object, Object>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longListMultimap = makeLongListMultimap();
-      var longListMultimapToListMultimapBuilder =
-          () => ListMultimapBuilder<int, int>(longListMultimap);
+      longListMultimapToListMultimapBuilder() =>
+          ListMultimapBuilder<int, int>(longListMultimap);
 
       expectNotMuchFaster(
           longListMultimapToListMultimapBuilder, makeLongListMultimap);
     });
 
     test('has fast toMap', () {
-      var makeLongListMultimap = () {
+      makeLongListMultimap() {
         var result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longListMultimap = makeLongListMultimap();
-      var longListMultimapToListMultimap = () => longListMultimap.toMap();
+      longListMultimapToListMultimap() => longListMultimap.toMap();
 
       expectMuchFaster(longListMultimapToListMultimap, makeLongListMultimap);
     });
 
     test('checks for reference identity', () {
-      var makeLongListMultimap = () {
+      makeLongListMultimap() {
         var result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longListMultimap = makeLongListMultimap();
       var otherLongListMultimap = makeLongListMultimap();
 

--- a/test/list_multimap/list_multimap_builder_test.dart
+++ b/test/list_multimap/list_multimap_builder_test.dart
@@ -123,15 +123,16 @@ void main() {
     });
 
     test('converts to BuiltListMultimap without copying', () {
-      var makeLongListMultimapBuilder = () {
+      makeLongListMultimapBuilder() {
         var result = ListMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(0, i);
         }
         return result;
-      };
+      }
+
       var longListMultimapBuilder = makeLongListMultimapBuilder();
-      var buildLongListMultimapBuilder = () => longListMultimapBuilder.build();
+      buildLongListMultimapBuilder() => longListMultimapBuilder.build();
 
       expectMuchFaster(
           buildLongListMultimapBuilder, makeLongListMultimapBuilder);

--- a/test/map/built_map_test.dart
+++ b/test/map/built_map_test.dart
@@ -288,7 +288,7 @@ void main() {
     });
 
     test('converts to MapBuilder from correct type without copying', () {
-      var makeLongMap = () => BuiltMap<int, int>(
+      makeLongMap() => BuiltMap<int, int>(
           Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)));
       var longMap = makeLongMap();
       var longMapToMapBuilder = longMap.toBuilder;
@@ -297,25 +297,25 @@ void main() {
     });
 
     test('converts to MapBuilder from wrong type by copying', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      makeLongMap() => BuiltMap<Object, Object>(
           Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)));
       var longMap = makeLongMap();
-      var longMapToMapBuilder = () => MapBuilder<int, int>(longMap);
+      longMapToMapBuilder() => MapBuilder<int, int>(longMap);
 
       expectNotMuchFaster(longMapToMapBuilder, makeLongMap);
     });
 
     test('has fast toMap', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      makeLongMap() => BuiltMap<Object, Object>(
           Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)));
       var longMap = makeLongMap();
-      var longMapToMap = () => longMap.toMap();
+      longMapToMap() => longMap.toMap();
 
       expectMuchFaster(longMapToMap, makeLongMap);
     });
 
     test('checks for reference identity', () {
-      var makeLongMap = () => BuiltMap<Object, Object>(
+      makeLongMap() => BuiltMap<Object, Object>(
           Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)));
       var longMap = makeLongMap();
       var otherLongMap = makeLongMap();

--- a/test/map/map_builder_test.dart
+++ b/test/map/map_builder_test.dart
@@ -140,7 +140,7 @@ void main() {
     });
 
     test('reuses BuiltMap passed to replace if it has the same base', () {
-      var treeMapBase = () => SplayTreeMap<int, String>();
+      treeMapBase() => SplayTreeMap<int, String>();
       var map = BuiltMap<int, String>.build((b) => b
         ..withBase(treeMapBase)
         ..addAll({1: '1', 2: '2'}));
@@ -183,10 +183,10 @@ void main() {
     });
 
     test('converts to BuiltMap without copying', () {
-      var makeLongMapBuilder = () => MapBuilder<int, int>(
+      makeLongMapBuilder() => MapBuilder<int, int>(
           Map<int, int>.fromIterable(List<int>.generate(100000, (x) => x)));
       var longMapBuilder = makeLongMapBuilder();
-      var buildLongMapBuilder = () => longMapBuilder.build();
+      buildLongMapBuilder() => longMapBuilder.build();
 
       expectMuchFaster(buildLongMapBuilder, makeLongMapBuilder);
     });
@@ -205,8 +205,8 @@ void main() {
 
     test('has a method like Map[]', () {
       var mapBuilder = MapBuilder<int, String>({1: '1', 2: '2'});
-      mapBuilder[1] = mapBuilder[1]! + '*';
-      mapBuilder[2] = mapBuilder[2]! + '**';
+      mapBuilder[1] = '${mapBuilder[1]!}*';
+      mapBuilder[2] = '${mapBuilder[2]!}**';
       expect(mapBuilder.build().asMap(), {1: '1*', 2: '2**'});
     });
 
@@ -319,13 +319,13 @@ void main() {
     test('has a method like Map.update called updateValue', () {
       expect(
           (MapBuilder<int, String>({1: '1', 2: '2'})
-                ..updateValue(1, (v) => v + '1', ifAbsent: () => '7'))
+                ..updateValue(1, (v) => '${v}1', ifAbsent: () => '7'))
               .build()
               .toMap(),
           {1: '11', 2: '2'});
       expect(
           (MapBuilder<int, String>({1: '1', 2: '2'})
-                ..updateValue(7, (v) => v + '1', ifAbsent: () => '7'))
+                ..updateValue(7, (v) => '${v}1', ifAbsent: () => '7'))
               .build()
               .toMap(),
           {1: '1', 2: '2', 7: '7'});

--- a/test/set/set_builder_test.dart
+++ b/test/set/set_builder_test.dart
@@ -90,7 +90,7 @@ void main() {
     });
 
     test('reuses BuiltSet passed to replace if it has the same base', () {
-      var treeSetBase = () => SplayTreeSet<int>();
+      treeSetBase() => SplayTreeSet<int>();
       var set = BuiltSet<int>.build((b) => b
         ..withBase(treeSetBase)
         ..addAll([1, 2]));
@@ -137,10 +137,10 @@ void main() {
     });
 
     test('converts to BuiltSet without copying', () {
-      var makeLongSetBuilder = () =>
+      makeLongSetBuilder() =>
           SetBuilder<int>(Set<int>.from(List<int>.generate(100000, (x) => x)));
       var longSetBuilder = makeLongSetBuilder();
-      var buildLongSetBuilder = () => longSetBuilder.build();
+      buildLongSetBuilder() => longSetBuilder.build();
 
       expectMuchFaster(buildLongSetBuilder, makeLongSetBuilder);
     });

--- a/test/set_multimap/built_set_multimap_test.dart
+++ b/test/set_multimap/built_set_multimap_test.dart
@@ -384,13 +384,14 @@ void main() {
 
     test('converts to SetMultimapBuilder from correct type without copying',
         () {
-      var makeLongSetMultimap = () {
+      makeLongSetMultimap() {
         var result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longSetMultimap = makeLongSetMultimap();
       var longSetMultimapToSetMultimapBuilder = longSetMultimap.toBuilder;
 
@@ -399,43 +400,46 @@ void main() {
     });
 
     test('converts to SetMultimapBuilder from wrong type by copying', () {
-      var makeLongSetMultimap = () {
+      makeLongSetMultimap() {
         var result = SetMultimapBuilder<Object, Object>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longSetMultimap = makeLongSetMultimap();
-      var longSetMultimapToSetMultimapBuilder =
-          () => SetMultimapBuilder<int, int>(longSetMultimap);
+      longSetMultimapToSetMultimapBuilder() =>
+          SetMultimapBuilder<int, int>(longSetMultimap);
 
       expectNotMuchFaster(
           longSetMultimapToSetMultimapBuilder, makeLongSetMultimap);
     });
 
     test('has fast toMap', () {
-      var makeLongSetMultimap = () {
+      makeLongSetMultimap() {
         var result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longSetMultimap = makeLongSetMultimap();
-      var longSetMultimapToSetMultimap = () => longSetMultimap.toMap();
+      longSetMultimapToSetMultimap() => longSetMultimap.toMap();
 
       expectMuchFaster(longSetMultimapToSetMultimap, makeLongSetMultimap);
     });
 
     test('checks for reference identity', () {
-      var makeLongSetMultimap = () {
+      makeLongSetMultimap() {
         var result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(i, i);
         }
         return result.build();
-      };
+      }
+
       var longSetMultimap = makeLongSetMultimap();
       var otherLongSetMultimap = makeLongSetMultimap();
 

--- a/test/set_multimap/set_multimap_builder_test.dart
+++ b/test/set_multimap/set_multimap_builder_test.dart
@@ -122,15 +122,16 @@ void main() {
     });
 
     test('converts to BuiltSetMultimap without copying', () {
-      var makeLongSetMultimapBuilder = () {
+      makeLongSetMultimapBuilder() {
         var result = SetMultimapBuilder<int, int>();
         for (var i = 0; i != 100000; ++i) {
           result.add(0, i);
         }
         return result;
-      };
+      }
+
       var longSetMultimapBuilder = makeLongSetMultimapBuilder();
-      var buildLongSetMultimapBuilder = () => longSetMultimapBuilder.build();
+      buildLongSetMultimapBuilder() => longSetMultimapBuilder.build();
 
       expectMuchFaster(buildLongSetMultimapBuilder, makeLongSetMultimapBuilder);
     });


### PR DESCRIPTION
-   Depends on SDK 3.0.0.
-   Removes null-soundness checks.
-   Changes pedantic lints to official lints. Fixes new lint warnings.
-   `BuiltList` and `BuiltSet` have "efficient" `.toList()` and `.toSet()`
    which reuses the backing list/set in a `CopyOnWrite{List,Set}`,
    and only makes a copy if that list is written to.
    The lazy operations returning a view on the type should not
    be based on the shared view.
    Similar issue exists for maps, but is harder to fix.